### PR TITLE
V0.5.0 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Available under the [MIT](https://en.wikipedia.org/wiki/MIT_License) license.
   * Customizable nearest neighbor searches, [metrics](https://en.wikipedia.org/wiki/Metric_(mathematics)) and tree splitting techniques.
   * Compile time and run time known dimensions.
   * Static tree builds.
+  * Thread safe queries.
 
 The examples show how PicoTree can be used:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available under the [MIT](https://en.wikipedia.org/wiki/MIT_License) license.
 
 The examples show how PicoTree can be used:
 
-* Creating an [adaptor](./examples/pico_common/pico_adaptor.hpp) to interface with input point clouds.
+* Creating the expected [point](./examples/pico_common/point.hpp) and [point set](./examples/pico_common/pico_adaptor.hpp) interfaces.
 * Searching using the [KdTree](./examples/kd_tree/kd_tree.cpp) and creating a custom search visitor (for finding approximate nearest neighbors).
 * Using [Eigen](./examples/eigen/) data types.
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -20,7 +20,7 @@ The different KdTree implementations are compared to each other with respect to 
 
 * Build algorithm: Dimensions known at compile time or run time.
 * Radius search algorithm: The radius in meters divided by 4 (0.25m and 0.5m).
-* Knn algorithm: The mount of neighbors searched.
+* Knn algorithm: The amount of neighbors searched.
 
 Note that the run time describes a single invocation of the build algorithm and n invocations of the others.
 

--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -95,7 +95,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtNanoBuildTree)(benchmark::State& state) {
   NanoAdaptorX adaptor(points_);
   for (auto _ : state) {
     NanoKdTreeCt<NanoAdaptorX> tree(
-        PointX::Dims,
+        PointX::Dim,
         adaptor,
         nanoflann::KDTreeSingleIndexAdaptorParams(max_leaf_size));
     tree.buildIndex();
@@ -125,7 +125,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, RtNanoBuildTree)(benchmark::State& state) {
   NanoAdaptorX adaptor(points_);
   for (auto _ : state) {
     NanoKdTreeRt<NanoAdaptorX> tree(
-        PointX::Dims,
+        PointX::Dim,
         adaptor,
         nanoflann::KDTreeSingleIndexAdaptorParams(max_leaf_size));
     tree.buildIndex();
@@ -186,7 +186,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtNanoKnn)(benchmark::State& state) {
   int knn_count = state.range(1);
   NanoAdaptorX adaptor(points_);
   NanoKdTreeCt<NanoAdaptorX> tree(
-      PointX::Dims,
+      PointX::Dim,
       adaptor,
       nanoflann::KDTreeSingleIndexAdaptorParams(max_leaf_size));
   tree.buildIndex();
@@ -317,7 +317,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtNanoRadius)(benchmark::State& state) {
   double squared = radius * radius;
   NanoAdaptorX adaptor(points_);
   NanoKdTreeCt<NanoAdaptorX> tree(
-      PointX::Dims,
+      PointX::Dim,
       adaptor,
       nanoflann::KDTreeSingleIndexAdaptorParams(max_leaf_size));
   tree.buildIndex();

--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -7,12 +7,8 @@
 #include "format_bin.hpp"
 #include "nano_adaptor.hpp"
 
-template <int Dims, typename PicoAdaptor>
-using MetricL2 = pico_tree::MetricL2<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
-    Dims,
-    PicoAdaptor>;
+template <int Dim, typename PicoAdaptor>
+using MetricL2 = pico_tree::MetricL2<typename PicoAdaptor::Scalar, Dim>;
 
 template <int Dims, typename PicoAdaptor>
 using SplitterLongestMedian = pico_tree::SplitterLongestMedian<

--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -25,17 +25,17 @@ template <typename PicoAdaptor>
 using PicoKdTreeCtSldMid = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    PicoAdaptor::Dims,
+    PicoAdaptor::Dim,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>
 using PicoKdTreeCtLngMed = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    PicoAdaptor::Dims,
+    PicoAdaptor::Dim,
     PicoAdaptor,
-    MetricL2<PicoAdaptor::Dims, PicoAdaptor>,
-    SplitterLongestMedian<PicoAdaptor::Dims, PicoAdaptor>>;
+    MetricL2<PicoAdaptor::Dim, PicoAdaptor>,
+    SplitterLongestMedian<PicoAdaptor::Dim, PicoAdaptor>>;
 
 template <typename PicoAdaptor>
 using PicoKdTreeRtSldMid = pico_tree::KdTree<

--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -57,7 +57,7 @@ template <typename NanoAdaptor>
 using NanoKdTreeCt = nanoflann::KDTreeSingleIndexAdaptor<
     nanoflann::L2_Simple_Adaptor<typename NanoAdaptor::Scalar, NanoAdaptor>,
     NanoAdaptor,
-    NanoAdaptor::Dims,
+    NanoAdaptor::Dim,
     typename NanoAdaptor::Index>;
 
 template <typename NanoAdaptor>

--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -41,17 +41,17 @@ template <typename PicoAdaptor>
 using PicoKdTreeRtSldMid = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    pico_tree::kRuntimeDims,
+    pico_tree::kDynamicDim,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>
 using PicoKdTreeRtLngMed = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    pico_tree::kRuntimeDims,
+    pico_tree::kDynamicDim,
     PicoAdaptor,
-    MetricL2<pico_tree::kRuntimeDims, PicoAdaptor>,
-    SplitterLongestMedian<pico_tree::kRuntimeDims, PicoAdaptor>>;
+    MetricL2<pico_tree::kDynamicDim, PicoAdaptor>,
+    SplitterLongestMedian<pico_tree::kDynamicDim, PicoAdaptor>>;
 
 template <typename NanoAdaptor>
 using NanoKdTreeCt = nanoflann::KDTreeSingleIndexAdaptor<

--- a/examples/benchmark/nano_adaptor.hpp
+++ b/examples/benchmark/nano_adaptor.hpp
@@ -10,7 +10,7 @@ class NanoAdaptor {
   using Index = Index_;
   using Point = Point_;
   using Scalar = typename Point::Scalar;
-  static constexpr int Dims = Point::Dims;
+  static constexpr int Dims = Point::Dim;
 
   NanoAdaptor(std::vector<Point> const& points) : points_(points) {}
 

--- a/examples/benchmark/nano_adaptor.hpp
+++ b/examples/benchmark/nano_adaptor.hpp
@@ -10,7 +10,7 @@ class NanoAdaptor {
   using Index = Index_;
   using Point = Point_;
   using Scalar = typename Point::Scalar;
-  static constexpr int Dims = Point::Dim;
+  static constexpr int Dim = Point::Dim;
 
   NanoAdaptor(std::vector<Point> const& points) : points_(points) {}
 

--- a/examples/eigen/eigen.cpp
+++ b/examples/eigen/eigen.cpp
@@ -1,7 +1,7 @@
 #include <Eigen/Dense>
 #include <pico_tree/eigen_adaptor.hpp>
 #include <pico_tree/kd_tree.hpp>
-#include <point.hpp>
+#include <random>
 #include <scoped_timer.hpp>
 
 using Index = int;

--- a/examples/eigen/eigen.cpp
+++ b/examples/eigen/eigen.cpp
@@ -29,8 +29,9 @@ std::vector<Point, Eigen::aligned_allocator<Point>> GenerateRandomEigenN(
 
 template <typename Adaptor>
 void AdaptorCout(Adaptor const& a, Index idx) {
-  Index num_dims = a.num_dimensions();
-  for (Index i = 0; i < num_dims; ++i) std::cout << a(idx, i) << " ";
+  for (int i = 0; i < a.sdim(); ++i) {
+    std::cout << a(idx, i) << " ";
+  }
   std::cout << std::endl;
 }
 

--- a/examples/eigen/eigen.cpp
+++ b/examples/eigen/eigen.cpp
@@ -30,7 +30,7 @@ std::vector<Point, Eigen::aligned_allocator<Point>> GenerateRandomEigenN(
 template <typename Adaptor>
 void AdaptorCout(Adaptor const& a, Index idx) {
   for (int i = 0; i < a.sdim(); ++i) {
-    std::cout << a(idx, i) << " ";
+    std::cout << a(idx)(i) << " ";
   }
   std::cout << std::endl;
 }

--- a/examples/eigen/eigen.cpp
+++ b/examples/eigen/eigen.cpp
@@ -36,13 +36,13 @@ void AdaptorCout(Adaptor const& a, Index idx) {
 
 void ColMajor() {
   using Point = Eigen::Vector3d;
-  constexpr int Dims = Point::RowsAtCompileTime;
+  constexpr int Dim = Point::RowsAtCompileTime;
   using PointsMap =
-      Eigen::Map<Eigen::Matrix<Point::Scalar, Dims, Eigen::Dynamic>>;
+      Eigen::Map<Eigen::Matrix<Point::Scalar, Dim, Eigen::Dynamic>>;
   using Adaptor = pico_tree::EigenAdaptor<Index, PointsMap>;
 
   auto points = GenerateRandomEigenN<Point>(kNumPoints, kArea);
-  PointsMap points_map(points.data()->data(), Dims, points.size());
+  PointsMap points_map(points.data()->data(), Dim, points.size());
   Adaptor adaptor(points_map);
 
   Point p = Point::Random() * kArea / typename Point::Scalar(2.0);
@@ -52,7 +52,7 @@ void ColMajor() {
   std::cout << "RowMajor: " << Adaptor::RowMajor << std::endl;
 
   {
-    pico_tree::KdTree<Index, Point::Scalar, Dims, Adaptor> rt(
+    pico_tree::KdTree<Index, Point::Scalar, Dim, Adaptor> rt(
         adaptor, kMaxLeafCount);
 
     std::vector<std::pair<Index, Scalar>> knn;
@@ -65,13 +65,13 @@ void ColMajor() {
 
 void RowMajor() {
   using Point = Eigen::RowVector3d;
-  constexpr int Dims = Point::ColsAtCompileTime;
+  constexpr int Dim = Point::ColsAtCompileTime;
   using PointsMap = Eigen::Map<
-      Eigen::Matrix<Point::Scalar, Eigen::Dynamic, Dims, Eigen::RowMajor>>;
+      Eigen::Matrix<Point::Scalar, Eigen::Dynamic, Dim, Eigen::RowMajor>>;
   using Adaptor = pico_tree::EigenAdaptor<Index, PointsMap>;
 
   auto points = GenerateRandomEigenN<Point>(kNumPoints, kArea);
-  PointsMap points_map(points.data()->data(), points.size(), Dims);
+  PointsMap points_map(points.data()->data(), points.size(), Dim);
   Adaptor adaptor(points_map);
 
   Point p = Point::Random() * kArea / typename Point::Scalar(2.0);
@@ -81,7 +81,7 @@ void RowMajor() {
   std::cout << "RowMajor: " << Adaptor::RowMajor << std::endl;
 
   {
-    pico_tree::KdTree<Index, Point::Scalar, Dims, Adaptor> rt(
+    pico_tree::KdTree<Index, Point::Scalar, Dim, Adaptor> rt(
         adaptor, kMaxLeafCount);
 
     std::vector<std::pair<Index, Scalar>> knn;

--- a/examples/kd_tree/kd_tree.cpp
+++ b/examples/kd_tree/kd_tree.cpp
@@ -13,7 +13,7 @@ template <typename PicoAdaptor>
 using KdTreeRt = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    pico_tree::kRuntimeDims,
+    pico_tree::kDynamicDim,
     PicoAdaptor>;
 
 // Compile time or run time known dimensions.

--- a/examples/kd_tree/kd_tree.cpp
+++ b/examples/kd_tree/kd_tree.cpp
@@ -6,7 +6,7 @@ template <typename PicoAdaptor>
 using KdTreeCt = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    PicoAdaptor::Dims,
+    PicoAdaptor::Dim,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -15,21 +15,14 @@ class PicoAdaptor {
 
   explicit PicoAdaptor(std::vector<Point> const& points) : points_(points) {}
 
-  //! Returns dimension \p dim of point \p idx.
-  inline Scalar operator()(Index const idx, int const dim) const {
-    return points_[idx](dim);
-  }
+  //! \brief Returns the point at index \p idx.
+  inline Point const& operator()(Index const idx) const { return points_[idx]; }
 
-  //! Returns dimension \p dim of point \p point.
-  inline Scalar operator()(Point const& point, int const dim) const {
-    return point(dim);
-  }
-
-  //! Returns the dimension of the space in which the points reside. I.e., the
-  //! amount of coordinates each point has.
+  //! \brief Returns the dimension of the space in which the points reside.
+  //! I.e., the amount of coordinates each point has.
   inline int sdim() const { return Dim; };
 
-  //! Returns the number of points.
+  //! \brief Returns the number of points.
   inline Index npts() const { return static_cast<Index>(points_.size()); };
 
  private:

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -9,7 +9,7 @@ class PicoAdaptor {
   using Index = Index_;
   using Point = Point_;
   using Scalar = typename Point::Scalar;
-  static constexpr int Dims = Point::Dims;
+  static constexpr int Dims = Point::Dim;
 
   explicit PicoAdaptor(std::vector<Point> const& points) : points_(points) {}
 

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -3,8 +3,13 @@
 #include "point.hpp"
 
 //! \brief Example point set. In this case the set is implemented as an adaptor
-//! that wraps a vector of Point. It illustrates which functions need to be
-//! implemented.
+//! that wraps a vector of Point.
+//! \details The following methods need to be implemented:
+//! \code{.cpp}
+//! inline Point const& operator()(Index const idx) const;
+//! inline int sdim() const;
+//! inline Index npts() const;
+//! \endcode
 template <typename Index_, typename Point_>
 class PicoAdaptor {
  public:

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -2,14 +2,15 @@
 
 #include "point.hpp"
 
-//! Example point set adaptor that shows which functions need to be implemented.
+//! \brief Example point set adaptor that shows which functions need to be
+//! implemented.
 template <typename Index_, typename Point_>
 class PicoAdaptor {
  public:
   using Index = Index_;
   using Point = Point_;
   using Scalar = typename Point::Scalar;
-  static constexpr int Dims = Point::Dim;
+  static constexpr int Dim = Point::Dim;
 
   explicit PicoAdaptor(std::vector<Point> const& points) : points_(points) {}
 
@@ -24,7 +25,7 @@ class PicoAdaptor {
   }
 
   //! Returns the amount of spatial dimensions of the points.
-  inline Index num_dimensions() const { return Dims; };
+  inline Index num_dimensions() const { return Dim; };
 
   //! Returns the number of points.
   inline Index num_points() const {

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -30,9 +30,7 @@ class PicoAdaptor {
   inline int sdim() const { return Dim; };
 
   //! Returns the number of points.
-  inline Index num_points() const {
-    return static_cast<Index>(points_.size());
-  };
+  inline Index npts() const { return static_cast<Index>(points_.size()); };
 
  private:
   std::vector<Point> const& points_;

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -15,17 +15,17 @@ class PicoAdaptor {
   explicit PicoAdaptor(std::vector<Point> const& points) : points_(points) {}
 
   //! Returns dimension \p dim of point \p idx.
-  inline Scalar operator()(Index const idx, Index const dim) const {
+  inline Scalar operator()(Index const idx, int const dim) const {
     return points_[idx](dim);
   }
 
   //! Returns dimension \p dim of point \p point.
-  inline Scalar operator()(Point const& point, Index const dim) const {
+  inline Scalar operator()(Point const& point, int const dim) const {
     return point(dim);
   }
 
   //! Returns the amount of spatial dimensions of the points.
-  inline Index num_dimensions() const { return Dim; };
+  inline int num_dimensions() const { return Dim; };
 
   //! Returns the number of points.
   inline Index num_points() const {

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -2,7 +2,8 @@
 
 #include "point.hpp"
 
-//! \brief Example point set adaptor that shows which functions need to be
+//! \brief Example point set. In this case the set is implemented as an adaptor
+//! that wraps a vector of Point. It illustrates which functions need to be
 //! implemented.
 template <typename Index_, typename Point_>
 class PicoAdaptor {
@@ -24,8 +25,9 @@ class PicoAdaptor {
     return point(dim);
   }
 
-  //! Returns the amount of spatial dimensions of the points.
-  inline int num_dimensions() const { return Dim; };
+  //! Returns the dimension of the space in which the points reside. I.e., the
+  //! amount of coordinates each point has.
+  inline int sdim() const { return Dim; };
 
   //! Returns the number of points.
   inline Index num_points() const {

--- a/examples/pico_common/point.hpp
+++ b/examples/pico_common/point.hpp
@@ -6,6 +6,10 @@
 #include <vector>
 
 //! \brief Example point type.
+//! \details A point should at least implement the parenthesis operator:
+//! \code{.cpp}
+//! inline Scalar const& operator()(int i) const;
+//! \endcode
 //! \tparam Scalar_ Coordinate value type.
 //! \tparam Dim_ The dimension of the space in which the point resides.
 template <typename Scalar_, int Dim_>

--- a/examples/pico_common/point.hpp
+++ b/examples/pico_common/point.hpp
@@ -6,29 +6,29 @@
 #include <vector>
 
 //! Demo point type.
-template <typename Scalar_, int Dims_>
+template <typename Scalar_, int Dim_>
 class Point {
  public:
   using Scalar = Scalar_;
-  static constexpr int Dims = Dims_;
+  static constexpr int Dim = Dim_;
 
-  inline Scalar const& operator()(int dim) const { return data[dim]; }
-  inline Scalar& operator()(int dim) { return data[dim]; }
+  inline Scalar const& operator()(int i) const { return data[i]; }
+  inline Scalar& operator()(int i) { return data[i]; }
 
   inline void Fill(Scalar const v) {
-    for (int i = 0; i < Dims; ++i) {
+    for (int i = 0; i < Dim; ++i) {
       data[i] = v;
     }
   }
 
-  Scalar data[Dims];
+  Scalar data[Dim];
 };
 
-template <typename Scalar_, int Dims_>
+template <typename Scalar_, int Dim_>
 inline std::ostream& operator<<(
-    std::ostream& s, Point<Scalar_, Dims_> const& p) {
+    std::ostream& s, Point<Scalar_, Dim_> const& p) {
   s << p(0);
-  for (int i = 1; i < Dims_; ++i) {
+  for (int i = 1; i < Dim_; ++i) {
     s << " " << p(i);
   }
   return s;
@@ -48,7 +48,7 @@ inline Point GenerateRandomP(typename Point::Scalar size) {
   std::uniform_real_distribution<typename Point::Scalar> dist(0, size);
 
   Point p;
-  for (int i = 0; i < Point::Dims; ++i) {
+  for (int i = 0; i < Point::Dim; ++i) {
     p(i) = dist(e2);
   }
 
@@ -64,7 +64,7 @@ std::vector<Point> GenerateRandomN(int n, typename Point::Scalar size) {
 
   std::vector<Point> random(n);
   for (auto& p : random) {
-    for (int i = 0; i < Point::Dims; ++i) {
+    for (int i = 0; i < Point::Dim; ++i) {
       p(i) = dist(e2);
     }
   }

--- a/examples/pico_common/point.hpp
+++ b/examples/pico_common/point.hpp
@@ -5,7 +5,9 @@
 #include <random>
 #include <vector>
 
-//! Demo point type.
+//! \brief Example point type.
+//! \tparam Scalar_ Coordinate value type.
+//! \tparam Dim_ The dimension of the space in which the point resides.
 template <typename Scalar_, int Dim_>
 class Point {
  public:

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -82,14 +82,14 @@ inline void ReplaceFrontHeap(
 
 //! \brief Compile time dimension count handling.
 template <int Dim_>
-struct Dimensions {
-  inline static constexpr int Dims(int) { return Dim_; }
+struct Dimension {
+  inline static constexpr int Dim(int) { return Dim_; }
 };
 
 //! \brief Run time dimension count handling.
 template <>
-struct Dimensions<kRuntimeDims> {
-  inline static int Dims(int dim) { return dim; }
+struct Dimension<kRuntimeDims> {
+  inline static int Dim(int dim) { return dim; }
 };
 
 //! \brief Compile time sequence. A lot faster than the run time version.

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -13,9 +13,11 @@
 
 namespace pico_tree {
 
-//! Value used for any template Dims parameter to determine the dimensions
-//! compile time.
-constexpr int kRuntimeDims = -1;
+//! \brief This value can be used in any template argument that wants to know
+//! the spatial dimension of the search problem when it can only be known at
+//! run-time. In this case the dimension of the problem is provided by the point
+//! adaptor.
+static constexpr int kDynamicDim = -1;
 
 namespace internal {
 
@@ -88,7 +90,7 @@ struct Dimension {
 
 //! \brief Run time dimension count handling.
 template <>
-struct Dimension<kRuntimeDims> {
+struct Dimension<kDynamicDim> {
   inline static int Dim(int dim) { return dim; }
 };
 
@@ -130,7 +132,7 @@ class Sequence {
 
 //! \brief Run time sequence. More flexible than the compile time one.
 template <typename Scalar>
-class Sequence<Scalar, kRuntimeDims> {
+class Sequence<Scalar, kDynamicDim> {
  public:
   //! \brief Return type of the Move() member function.
   //! \details Moving a vector is quite a bit cheaper than copying it. The

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
-//! \mainpage PicoTree is a small C++11 header only library that provides
-//! several data structures that can be used for range searches and nearest
-//! neighbor searches. It is only dependent on the C++ Standard Library. The
-//! following search structures are provided:
-//! \li <a href="https://en.wikipedia.org/wiki/K-d_tree">Kd Tree</a>.
-//! \li <a href="https://en.wikipedia.org/wiki/Fractional_cascading">Layered</a>
-//! <a href="https://en.wikipedia.org/wiki/Range_tree">Range Tree</a>.
+//! \mainpage PicoTree is a small C++ header only library for range searches and
+//! nearest neighbor searches using a KdTree.
 //! \file core.hpp
 //! \brief Contains various common utilities.
 
@@ -86,23 +81,19 @@ inline void ReplaceFrontHeap(
 }
 
 //! \brief Compile time dimension count handling.
-template <int Dims_>
+template <int Dim_>
 struct Dimensions {
-  //! \brief Returns the dimension index of the \p dim -th dimension from the
-  //! back.
-  inline static constexpr int Back(int dim) { return Dims_ - dim; }
-  inline static constexpr int Dims(int) { return Dims_; }
+  inline static constexpr int Dims(int) { return Dim_; }
 };
 
 //! \brief Run time dimension count handling.
 template <>
 struct Dimensions<kRuntimeDims> {
-  inline static constexpr int Back(int) { return kRuntimeDims; }
-  inline static int Dims(int dims) { return dims; }
+  inline static int Dims(int dim) { return dim; }
 };
 
 //! \brief Compile time sequence. A lot faster than the run time version.
-template <typename Scalar, int Dims_>
+template <typename Scalar, int Dim_>
 class Sequence {
  public:
   //! \brief Return type of the Move() member function.
@@ -134,7 +125,7 @@ class Sequence {
 
  private:
   //! Storage.
-  std::array<Scalar, Dims_> sequence_;
+  std::array<Scalar, Dim_> sequence_;
 };
 
 //! \brief Run time sequence. More flexible than the compile time one.

--- a/src/pico_tree/eigen_adaptor.hpp
+++ b/src/pico_tree/eigen_adaptor.hpp
@@ -29,8 +29,9 @@ class EigenAdaptorBase<Index_, EigenMatrix, false> {
     return point(dim);
   }
 
-  //! Returns the amount of spatial dimensions of the points.
-  inline Index num_dimensions() const { return matrix_.rows(); };
+  //! Returns the dimension of the space in which the points reside. I.e., the
+  //! amount of coordinates each point has.
+  inline int sdim() const { return matrix_.rows(); };
 
   //! Returns the number of points.
   inline Index num_points() const { return matrix_.cols(); };
@@ -61,8 +62,9 @@ class EigenAdaptorBase<Index_, EigenMatrix, true> {
     return point(dim);
   }
 
-  //! Returns the amount of spatial dimensions of the points.
-  inline Index num_dimensions() const { return matrix_.cols(); };
+  //! Returns the dimension of the space in which the points reside. I.e., the
+  //! amount of coordinates each point has.
+  inline int sdim() const { return matrix_.cols(); };
 
   //! Returns the number of points.
   inline Index num_points() const { return matrix_.rows(); };

--- a/src/pico_tree/eigen_adaptor.hpp
+++ b/src/pico_tree/eigen_adaptor.hpp
@@ -34,7 +34,7 @@ class EigenAdaptorBase<Index_, EigenMatrix, false> {
   inline int sdim() const { return matrix_.rows(); };
 
   //! Returns the number of points.
-  inline Index num_points() const { return matrix_.cols(); };
+  inline Index npts() const { return matrix_.cols(); };
 
  private:
   EigenMatrix matrix_;
@@ -67,7 +67,7 @@ class EigenAdaptorBase<Index_, EigenMatrix, true> {
   inline int sdim() const { return matrix_.cols(); };
 
   //! Returns the number of points.
-  inline Index num_points() const { return matrix_.rows(); };
+  inline Index npts() const { return matrix_.rows(); };
 
  private:
   EigenMatrix matrix_;

--- a/src/pico_tree/eigen_adaptor.hpp
+++ b/src/pico_tree/eigen_adaptor.hpp
@@ -7,7 +7,7 @@ namespace internal {
 template <typename Index, typename Matrix, bool RowMajor>
 class EigenAdaptorBase;
 
-//! ColMajor EigenAdaptor.
+//! \brief ColMajor EigenAdaptor.
 template <typename Index_, typename Matrix>
 class EigenAdaptorBase<Index_, Matrix, false> {
  public:
@@ -18,29 +18,24 @@ class EigenAdaptorBase<Index_, Matrix, false> {
 
   inline EigenAdaptorBase(Matrix const& matrix) : matrix_(matrix) {}
 
-  //! Returns dimension \p dim of point \p idx.
-  inline Scalar operator()(Index const idx, Index const dim) const {
-    return matrix_(dim, idx);
+  //! \brief Returns the point at index \p idx.
+  inline Eigen::Block<Matrix const, Dim, 1, !RowMajor> const operator()(
+      Index const idx) const {
+    return matrix_.col(idx);
   }
 
-  //! Returns dimension \p dim of point \p point.
-  template <typename Point>
-  inline Scalar operator()(Point const& point, Index const dim) const {
-    return point(dim);
-  }
-
-  //! Returns the dimension of the space in which the points reside. I.e., the
-  //! amount of coordinates each point has.
+  //! \brief Returns the dimension of the space in which the points reside.
+  //! I.e., the amount of coordinates each point has.
   inline int sdim() const { return matrix_.rows(); };
 
-  //! Returns the number of points.
-  inline Index npts() const { return matrix_.cols(); };
+  //! \brief Returns the number of points.
+  inline Index npts() const { return static_cast<Index>(matrix_.cols()); };
 
  private:
   Matrix matrix_;
 };
 
-//! RowMajor EigenAdaptor.
+//! \brief RowMajor EigenAdaptor.
 template <typename Index_, typename Matrix>
 class EigenAdaptorBase<Index_, Matrix, true> {
  public:
@@ -51,23 +46,18 @@ class EigenAdaptorBase<Index_, Matrix, true> {
 
   inline EigenAdaptorBase(Matrix const& matrix) : matrix_(matrix) {}
 
-  //! Returns dimension \p dim of point \p idx.
-  inline Scalar operator()(Index const idx, Index const dim) const {
-    return matrix_(idx, dim);
+  //! \brief Returns the point at index \p idx.
+  inline Eigen::Block<Matrix const, 1, Dim, RowMajor> const operator()(
+      Index const idx) const {
+    return matrix_.row(idx);
   }
 
-  //! Returns dimension \p dim of point \p point.
-  template <typename Point>
-  inline Scalar operator()(Point const& point, Index const dim) const {
-    return point(dim);
-  }
-
-  //! Returns the dimension of the space in which the points reside. I.e., the
-  //! amount of coordinates each point has.
+  //! \brief Returns the dimension of the space in which the points reside.
+  //! I.e., the amount of coordinates each point has.
   inline int sdim() const { return matrix_.cols(); };
 
-  //! Returns the number of points.
-  inline Index npts() const { return matrix_.rows(); };
+  //! \brief Returns the number of points.
+  inline Index npts() const { return static_cast<Index>(matrix_.rows()); };
 
  private:
   Matrix matrix_;

--- a/src/pico_tree/eigen_adaptor.hpp
+++ b/src/pico_tree/eigen_adaptor.hpp
@@ -4,19 +4,19 @@ namespace pico_tree {
 
 namespace internal {
 
-template <typename Index, typename EigenMatrix, bool RowMajor>
+template <typename Index, typename Matrix, bool RowMajor>
 class EigenAdaptorBase;
 
 //! ColMajor EigenAdaptor.
-template <typename Index_, typename EigenMatrix>
-class EigenAdaptorBase<Index_, EigenMatrix, false> {
+template <typename Index_, typename Matrix>
+class EigenAdaptorBase<Index_, Matrix, false> {
  public:
   using Index = Index_;
-  using Scalar = typename EigenMatrix::Scalar;
-  static constexpr int Dim = EigenMatrix::RowsAtCompileTime;
+  using Scalar = typename Matrix::Scalar;
+  static constexpr int Dim = Matrix::RowsAtCompileTime;
   static constexpr bool RowMajor = false;
 
-  inline EigenAdaptorBase(EigenMatrix const& matrix) : matrix_(matrix) {}
+  inline EigenAdaptorBase(Matrix const& matrix) : matrix_(matrix) {}
 
   //! Returns dimension \p dim of point \p idx.
   inline Scalar operator()(Index const idx, Index const dim) const {
@@ -37,19 +37,19 @@ class EigenAdaptorBase<Index_, EigenMatrix, false> {
   inline Index npts() const { return matrix_.cols(); };
 
  private:
-  EigenMatrix matrix_;
+  Matrix matrix_;
 };
 
 //! RowMajor EigenAdaptor.
-template <typename Index_, typename EigenMatrix>
-class EigenAdaptorBase<Index_, EigenMatrix, true> {
+template <typename Index_, typename Matrix>
+class EigenAdaptorBase<Index_, Matrix, true> {
  public:
   using Index = Index_;
-  using Scalar = typename EigenMatrix::Scalar;
-  static constexpr int Dim = EigenMatrix::ColsAtCompileTime;
+  using Scalar = typename Matrix::Scalar;
+  static constexpr int Dim = Matrix::ColsAtCompileTime;
   static constexpr bool RowMajor = true;
 
-  inline EigenAdaptorBase(EigenMatrix const& matrix) : matrix_(matrix) {}
+  inline EigenAdaptorBase(Matrix const& matrix) : matrix_(matrix) {}
 
   //! Returns dimension \p dim of point \p idx.
   inline Scalar operator()(Index const idx, Index const dim) const {
@@ -70,21 +70,18 @@ class EigenAdaptorBase<Index_, EigenMatrix, true> {
   inline Index npts() const { return matrix_.rows(); };
 
  private:
-  EigenMatrix matrix_;
+  Matrix matrix_;
 };
 
 }  // namespace internal
 
 //! Adapts Eigen matrices so they can be used with any of the pico trees.
-template <typename Index, typename EigenMatrix>
+template <typename Index, typename Matrix>
 class EigenAdaptor
-    : public internal::
-          EigenAdaptorBase<Index, EigenMatrix, EigenMatrix::IsRowMajor> {
+    : public internal::EigenAdaptorBase<Index, Matrix, Matrix::IsRowMajor> {
  public:
-  using internal::EigenAdaptorBase<
-      Index,
-      EigenMatrix,
-      EigenMatrix::IsRowMajor>::EigenAdaptorBase;
+  using internal::EigenAdaptorBase<Index, Matrix, Matrix::IsRowMajor>::
+      EigenAdaptorBase;
 };
 
 }  // namespace pico_tree

--- a/src/pico_tree/eigen_adaptor.hpp
+++ b/src/pico_tree/eigen_adaptor.hpp
@@ -13,7 +13,7 @@ class EigenAdaptorBase<Index_, EigenMatrix, false> {
  public:
   using Index = Index_;
   using Scalar = typename EigenMatrix::Scalar;
-  static constexpr int Dims = EigenMatrix::RowsAtCompileTime;
+  static constexpr int Dim = EigenMatrix::RowsAtCompileTime;
   static constexpr bool RowMajor = false;
 
   inline EigenAdaptorBase(EigenMatrix const& matrix) : matrix_(matrix) {}
@@ -45,7 +45,7 @@ class EigenAdaptorBase<Index_, EigenMatrix, true> {
  public:
   using Index = Index_;
   using Scalar = typename EigenMatrix::Scalar;
-  static constexpr int Dims = EigenMatrix::ColsAtCompileTime;
+  static constexpr int Dim = EigenMatrix::ColsAtCompileTime;
   static constexpr bool RowMajor = true;
 
   inline EigenAdaptorBase(EigenMatrix const& matrix) : matrix_(matrix) {}

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -359,8 +359,8 @@ class SplitterSlidingMidpoint {
 
 //! \brief A KdTree is a binary tree that partitions space using hyper planes.
 //! \details https://en.wikipedia.org/wiki/K-d_tree
-//! \tparam Dim The spatial dimension of the tree and points.
-//! pico_tree::Dynamic in case of run time dimensions.
+//! \tparam Dim The spatial dimension of the tree and points. It can be set to
+//! pico_tree::kDynamicDim in case Dim is only known at run-time.
 template <
     typename Index,
     typename Scalar,

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -148,8 +148,7 @@ class MetricL1 {
   operator()(P const& p, Index const idx) const {
     Scalar d{};
 
-    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.num_dimensions());
-         ++i) {
+    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
       d += std::abs(points_(p, i) - points_(idx, i));
     }
 
@@ -191,8 +190,7 @@ class MetricL2 {
   operator()(P const& p, Index const idx) const {
     Scalar d{};
 
-    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.num_dimensions());
-         ++i) {
+    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
       Scalar const v = points_(p, i) - points_(idx, i);
       d += v * v;
     }
@@ -613,13 +611,11 @@ class KdTree {
   inline void CalculateBoundingBox(Sequence* p_min, Sequence* p_max) {
     Sequence& min = *p_min;
     Sequence& max = *p_max;
-    min.Fill(points_.num_dimensions(), std::numeric_limits<Scalar>::max());
-    max.Fill(points_.num_dimensions(), std::numeric_limits<Scalar>::lowest());
+    min.Fill(points_.sdim(), std::numeric_limits<Scalar>::max());
+    max.Fill(points_.sdim(), std::numeric_limits<Scalar>::lowest());
 
     for (Index j = 0; j < points_.num_points(); ++j) {
-      for (int i = 0;
-           i < internal::Dimension<Dim>::Dim(points_.num_dimensions());
-           ++i) {
+      for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
         Scalar const v = points_(j, i);
         if (v < min[i]) {
           min[i] = v;
@@ -692,9 +688,7 @@ class KdTree {
   //! point on the edge considered inside the box.
   template <typename P>
   inline bool PointInBox(Sequence const& p, P const& min, P const& max) const {
-    for (Index i = 0;
-         i < internal::Dimension<Dim>::Dim(points_.num_dimensions());
-         ++i) {
+    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
       if (points_(min, i) > p[i] || points_(max, i) < p[i]) {
         return false;
       }
@@ -706,9 +700,7 @@ class KdTree {
   //! by \p min and \p max. A point on the edge considered inside the box.
   template <typename P>
   inline bool PointInBox(Index const idx, P const& min, P const& max) const {
-    for (Index i = 0;
-         i < internal::Dimension<Dim>::Dim(points_.num_dimensions());
-         ++i) {
+    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
       Scalar const v = points_(idx, i);
       if (points_(min, i) > v || points_(max, i) < v) {
         return false;

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -475,8 +475,8 @@ class KdTree {
   KdTree(Points const& points, Index const max_leaf_size)
       : points_{points},
         metric_{points_},
-        nodes_(internal::MaxNodesFromPoints(points_.num_points())),
-        indices_(points_.num_points()),
+        nodes_(internal::MaxNodesFromPoints(points_.npts())),
+        indices_(points_.npts()),
         root_{Build(max_leaf_size)} {}
 
   //! \brief Returns the nearest neighbor (or neighbors) of point \p p depending
@@ -508,8 +508,7 @@ class KdTree {
       bool const sort = false) const {
     // If it happens that the point set is has less points than k we just return
     // all points in the set.
-    internal::SearchKnn<Index, Scalar> v(
-        std::min(k, points_.num_points()), knn);
+    internal::SearchKnn<Index, Scalar> v(std::min(k, points_.npts()), knn);
     SearchNn(root_, p, &v);
 
     if (sort) {
@@ -604,8 +603,8 @@ class KdTree {
   KdTree(Points const& points, internal::Stream* stream)
       : points_{points},
         metric_{points_},
-        nodes_(internal::MaxNodesFromPoints(points_.num_points())),
-        indices_(points_.num_points()),
+        nodes_(internal::MaxNodesFromPoints(points_.npts())),
+        indices_(points_.npts()),
         root_{Load(stream)} {}
 
   inline void CalculateBoundingBox(Sequence* p_min, Sequence* p_max) {
@@ -614,7 +613,7 @@ class KdTree {
     min.Fill(points_.sdim(), std::numeric_limits<Scalar>::max());
     max.Fill(points_.sdim(), std::numeric_limits<Scalar>::lowest());
 
-    for (Index j = 0; j < points_.num_points(); ++j) {
+    for (Index j = 0; j < points_.npts(); ++j) {
       for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
         Scalar const v = points_(j, i);
         if (v < min[i]) {
@@ -630,7 +629,7 @@ class KdTree {
   //! \brief Builds a tree given a \p max_leaf_size and a Splitter.
   //! \details Run time may vary depending on the split strategy.
   inline Node* Build(Index const max_leaf_size) {
-    assert(points_.num_points() > 0);
+    assert(points_.npts() > 0);
     assert(max_leaf_size > 0);
 
     std::iota(indices_.begin(), indices_.end(), 0);
@@ -639,11 +638,7 @@ class KdTree {
 
     Splitter splitter(points_, &indices_);
     return Builder{max_leaf_size, splitter, &nodes_}.SplitIndices(
-        0,
-        0,
-        points_.num_points(),
-        Sequence(root_box_min_),
-        Sequence(root_box_max_));
+        0, 0, points_.npts(), Sequence(root_box_min_), Sequence(root_box_max_));
   }
 
   //! Returns the nearest neighbor (or neighbors) of point \p p depending on

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -11,11 +11,11 @@ namespace pico_tree {
 namespace internal {
 
 //! See which axis of the box is the longest.
-template <typename Index, typename Scalar, int Dim>
+template <typename Scalar, int Dim>
 inline void LongestAxisBox(
     Sequence<Scalar, Dim> const& box_min,
     Sequence<Scalar, Dim> const& box_max,
-    Index* p_max_index,
+    int* p_max_index,
     Scalar* p_max_value) {
   assert(box_min.size() == box_max.size());
 
@@ -25,7 +25,7 @@ inline void LongestAxisBox(
        ++i) {
     Scalar const delta = box_max[i] - box_min[i];
     if (delta > *p_max_value) {
-      *p_max_index = static_cast<Index>(i);
+      *p_max_index = i;
       *p_max_value = delta;
     }
   }
@@ -247,7 +247,7 @@ class SplitterLongestMedian {
       Index const size,
       Sequence const& box_min,
       Sequence const& box_max,
-      Index* split_dim,
+      int* split_dim,
       Index* split_idx,
       Scalar* split_val) const {
     Points const& points = points_;
@@ -306,7 +306,7 @@ class SplitterSlidingMidpoint {
       Index const size,
       Sequence const& box_min,
       Sequence const& box_max,
-      Index* split_dim,
+      int* split_dim,
       Index* split_idx,
       Scalar* split_val) const {
     Scalar max_delta;

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -96,7 +96,7 @@ void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
   Index idx = tree.points().num_points() / 2;
   PointX p;
 
-  for (Index d = 0; d < PointsX::Dims; ++d) {
+  for (Index d = 0; d < PointX::Dim; ++d) {
     p(d) = points(idx, d);
   }
 
@@ -133,7 +133,7 @@ void TestKnn(Tree const& tree, TreeIndexType<Tree> const k) {
   Index idx = tree.points().num_points() / 2;
   PointX p;
 
-  for (Index d = 0; d < PointsX::Dims; ++d) {
+  for (Index d = 0; d < PointX::Dim; ++d) {
     p(d) = points(idx, d);
   }
 

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -16,15 +16,15 @@ template <typename P, typename Index, typename Scalar, typename Metric>
 void SearchKnn(
     P const& p,
     Index const k,
-    Index const num_points,
+    Index const npts,
     Metric const& metric,
     std::vector<std::pair<Index, Scalar>>* knn) {
-  knn->resize(static_cast<std::size_t>(num_points));
-  for (Index i = 0; i < num_points; ++i) {
+  knn->resize(static_cast<std::size_t>(npts));
+  for (Index i = 0; i < npts; ++i) {
     (*knn)[i] = {i, metric(p, i)};
   }
 
-  Index const max_k = std::min(k, num_points);
+  Index const max_k = std::min(k, npts);
   std::nth_element(
       knn->begin(),
       knn->begin() + (max_k - 1),
@@ -66,7 +66,7 @@ void TestBox(
 
   std::size_t count = 0;
 
-  for (Index j = 0; j < points.num_points(); ++j) {
+  for (Index j = 0; j < points.npts(); ++j) {
     bool contained = true;
 
     for (int d = 0; d < PointX::Dim; ++d) {
@@ -93,7 +93,7 @@ void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
 
   auto const& points = tree.points();
 
-  Index idx = tree.points().num_points() / 2;
+  Index idx = tree.points().npts() / 2;
   PointX p;
 
   for (Index d = 0; d < PointX::Dim; ++d) {
@@ -112,7 +112,7 @@ void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
 
   std::size_t count = 0;
 
-  for (Index j = 0; j < points.num_points(); ++j) {
+  for (Index j = 0; j < points.npts(); ++j) {
     if (metric(p, j) <= lp_radius) {
       count++;
     }
@@ -130,7 +130,7 @@ void TestKnn(Tree const& tree, TreeIndexType<Tree> const k) {
 
   auto const& points = tree.points();
 
-  Index idx = tree.points().num_points() / 2;
+  Index idx = tree.points().npts() / 2;
   PointX p;
 
   for (Index d = 0; d < PointX::Dim; ++d) {
@@ -141,7 +141,7 @@ void TestKnn(Tree const& tree, TreeIndexType<Tree> const k) {
   tree.SearchKnn(p, k, &results, true);
 
   std::vector<std::pair<Index, Scalar>> compare;
-  SearchKnn(p, k, points.num_points(), tree.metric(), &compare);
+  SearchKnn(p, k, points.npts(), tree.metric(), &compare);
 
   ASSERT_EQ(compare.size(), results.size());
   for (std::size_t i = 0; i < compare.size(); ++i) {

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -59,8 +59,8 @@ void TestBox(
 
   for (auto j : idxs) {
     for (int d = 0; d < PointX::Dim; ++d) {
-      EXPECT_GE(points(j, d), min_v);
-      EXPECT_LE(points(j, d), max_v);
+      EXPECT_GE(points(j)(d), min_v);
+      EXPECT_LE(points(j)(d), max_v);
     }
   }
 
@@ -70,7 +70,7 @@ void TestBox(
     bool contained = true;
 
     for (int d = 0; d < PointX::Dim; ++d) {
-      if ((points(j, d) < min_v) || (points(j, d) > max_v)) {
+      if ((points(j)(d) < min_v) || (points(j)(d) > max_v)) {
         contained = false;
         break;
       }
@@ -97,7 +97,7 @@ void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
   PointX p;
 
   for (Index d = 0; d < PointX::Dim; ++d) {
-    p(d) = points(idx, d);
+    p(d) = points(idx)(d);
   }
 
   auto const& metric = tree.metric();
@@ -134,7 +134,7 @@ void TestKnn(Tree const& tree, TreeIndexType<Tree> const k) {
   PointX p;
 
   for (Index d = 0; d < PointX::Dim; ++d) {
-    p(d) = points(idx, d);
+    p(d) = points(idx)(d);
   }
 
   std::vector<std::pair<Index, Scalar>> results;

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -58,7 +58,7 @@ void TestBox(
   tree.SearchBox(min, max, &idxs);
 
   for (auto j : idxs) {
-    for (int d = 0; d < PointX::Dims; ++d) {
+    for (int d = 0; d < PointX::Dim; ++d) {
       EXPECT_GE(points(j, d), min_v);
       EXPECT_LE(points(j, d), max_v);
     }
@@ -69,7 +69,7 @@ void TestBox(
   for (Index j = 0; j < points.num_points(); ++j) {
     bool contained = true;
 
-    for (int d = 0; d < PointX::Dims; ++d) {
+    for (int d = 0; d < PointX::Dim; ++d) {
       if ((points(j, d) < min_v) || (points(j, d) > max_v)) {
         contained = false;
         break;

--- a/test/kd_tree_test.cpp
+++ b/test/kd_tree_test.cpp
@@ -18,12 +18,12 @@ TEST(KdTreeTest, MetricL1) {
   using Index = int;
   using Scalar = typename PointX::Scalar;
   using AdaptorX = PicoAdaptor<Index, PointX>;
-  constexpr auto Dims = PointX::Dims;
+  constexpr auto Dim = PointX::Dim;
   std::vector<PointX> points{{2.0f, 4.0f}};
   AdaptorX adaptor(points);
   PointX p{10.0f, 1.0f};
 
-  pico_tree::MetricL1<Index, Scalar, Dims, AdaptorX> metric(adaptor);
+  pico_tree::MetricL1<Index, Scalar, Dim, AdaptorX> metric(adaptor);
 
   EXPECT_FLOAT_EQ(metric(p, 0), 11.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f, 8.9f), 12.0f);
@@ -35,12 +35,12 @@ TEST(KdTreeTest, MetricL2) {
   using Index = int;
   using Scalar = typename PointX::Scalar;
   using AdaptorX = PicoAdaptor<Index, PointX>;
-  constexpr auto Dims = PointX::Dims;
+  constexpr auto Dim = PointX::Dim;
   std::vector<PointX> points{{2.0f, 4.0f}};
   AdaptorX adaptor(points);
   PointX p{10.0f, 1.0f};
 
-  pico_tree::MetricL2<Index, Scalar, Dims, AdaptorX> metric(adaptor);
+  pico_tree::MetricL2<Index, Scalar, Dim, AdaptorX> metric(adaptor);
 
   EXPECT_FLOAT_EQ(metric(p, 0), 73.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f, 8.9f), 144.0f);
@@ -52,7 +52,7 @@ TEST(KdTreeTest, SplitterMedian) {
   using Index = int;
   using Scalar = typename PointX::Scalar;
   using AdaptorX = PicoAdaptor<Index, PointX>;
-  constexpr auto Dims = PointX::Dims;
+  constexpr auto Dim = PointX::Dim;
   std::vector<PointX> pts4{
       {0.0f, 4.0f}, {0.0f, 2.0f}, {0.0f, 3.0f}, {0.0f, 1.0f}};
   std::vector<Index> idx4{0, 1, 2, 3};
@@ -68,7 +68,7 @@ TEST(KdTreeTest, SplitterMedian) {
   Index split_idx;
   Scalar split_val;
 
-  pico_tree::SplitterLongestMedian<Index, Scalar, Dims, AdaptorX> splitter4(
+  pico_tree::SplitterLongestMedian<Index, Scalar, Dim, AdaptorX> splitter4(
       ptsx4, &idx4);
   splitter4(0, 0, 4, min, max, &split_dim, &split_idx, &split_val);
 
@@ -87,7 +87,7 @@ TEST(KdTreeTest, SplitterMedian) {
   std::vector<Index> idx7{0, 1, 2, 3, 4, 5, 6};
   AdaptorX ptsx7(pts7);
 
-  pico_tree::SplitterLongestMedian<Index, Scalar, Dims, AdaptorX> splitter7(
+  pico_tree::SplitterLongestMedian<Index, Scalar, Dim, AdaptorX> splitter7(
       ptsx7, &idx7);
   splitter7(0, 0, 7, min, max, &split_dim, &split_idx, &split_val);
 
@@ -108,12 +108,12 @@ TEST(KdTreeTest, SplitterSlidingMidpoint) {
   using Index = int;
   using Scalar = typename PointX::Scalar;
   using AdaptorX = PicoAdaptor<Index, PointX>;
-  constexpr auto Dims = PointX::Dims;
+  constexpr auto Dim = PointX::Dim;
   std::vector<PointX> pts4{{0.0, 2.0}, {0.0, 1.0}, {0.0, 4.0}, {0.0, 3.0}};
   std::vector<Index> idx4{0, 1, 2, 3};
   AdaptorX ptsx4(pts4);
 
-  pico_tree::SplitterSlidingMidpoint<Index, Scalar, Dims, AdaptorX> splitter(
+  pico_tree::SplitterSlidingMidpoint<Index, Scalar, Dim, AdaptorX> splitter(
       ptsx4, &idx4);
 
   pico_tree::internal::Sequence<Scalar, 2> min;

--- a/test/kd_tree_test.cpp
+++ b/test/kd_tree_test.cpp
@@ -10,7 +10,7 @@ template <typename PicoAdaptor>
 using KdTree = pico_tree::KdTree<
     typename PicoAdaptor::Index,
     typename PicoAdaptor::Scalar,
-    PicoAdaptor::Dims,
+    PicoAdaptor::Dim,
     PicoAdaptor>;
 
 TEST(KdTreeTest, MetricL1) {

--- a/test/kd_tree_test.cpp
+++ b/test/kd_tree_test.cpp
@@ -23,9 +23,9 @@ TEST(KdTreeTest, MetricL1) {
   AdaptorX adaptor(points);
   PointX p{10.0f, 1.0f};
 
-  pico_tree::MetricL1<Index, Scalar, Dim, AdaptorX> metric(adaptor);
+  pico_tree::MetricL1<Scalar, Dim> metric(adaptor.sdim());
 
-  EXPECT_FLOAT_EQ(metric(p, 0), 11.0f);
+  EXPECT_FLOAT_EQ(metric(p, adaptor(0)), 11.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f, 8.9f), 12.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f), 3.1f);
 }
@@ -40,9 +40,9 @@ TEST(KdTreeTest, MetricL2) {
   AdaptorX adaptor(points);
   PointX p{10.0f, 1.0f};
 
-  pico_tree::MetricL2<Index, Scalar, Dim, AdaptorX> metric(adaptor);
+  pico_tree::MetricL2<Scalar, Dim> metric(adaptor.sdim());
 
-  EXPECT_FLOAT_EQ(metric(p, 0), 73.0f);
+  EXPECT_FLOAT_EQ(metric(p, adaptor(0)), 73.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f, 8.9f), 144.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f), 9.61f);
 }


### PR DESCRIPTION
The following has been changed:

- Test and query points are no longer expected to provide their coordinates through a single interface (adaptor or point set). Implementations for both can be cleaner (and possibly different). 
  - Query points and test points should implement the parenthesis operator.
  - The input interface for adaptors or point sets has been simplified.
- The interface for Metric classes has been cleaned up and simplified: Reduced the amount of template arguments plus test and query points are now handled identically.