### PR TITLE
Neighbor and pool

### DIFF
--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -206,7 +206,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtSldMidPicoKnn)(benchmark::State& state) {
   PicoKdTreeCtSldMid<PicoAdaptorX> tree(adaptor, max_leaf_size);
 
   for (auto _ : state) {
-    std::vector<std::pair<Index, Scalar>> results;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> results;
     std::size_t sum = 0;
     for (auto const& p : points_) {
       tree.SearchKnn(p, knn_count, &results);
@@ -222,7 +222,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtLngMedPicoKnn)(benchmark::State& state) {
   PicoKdTreeCtLngMed<PicoAdaptorX> tree(adaptor, max_leaf_size);
 
   for (auto _ : state) {
-    std::vector<std::pair<Index, Scalar>> results;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> results;
     std::size_t sum = 0;
     for (auto const& p : points_) {
       tree.SearchKnn(p, knn_count, &results);
@@ -237,7 +237,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtSldMidPicoNn)(benchmark::State& state) {
   PicoKdTreeCtSldMid<PicoAdaptorX> tree(adaptor, max_leaf_size);
 
   for (auto _ : state) {
-    std::pair<Index, Scalar> result;
+    pico_tree::Neighbor<Index, Scalar> result;
     for (auto const& p : points_) {
       tree.SearchNn(p, &result);
     }
@@ -250,7 +250,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtLngMedPicoNn)(benchmark::State& state) {
   PicoKdTreeCtLngMed<PicoAdaptorX> tree(adaptor, max_leaf_size);
 
   for (auto _ : state) {
-    std::pair<Index, Scalar> result;
+    pico_tree::Neighbor<Index, Scalar> result;
     for (auto const& p : points_) {
       tree.SearchNn(p, &result);
     }
@@ -380,7 +380,7 @@ BENCHMARK_DEFINE_F(KdTreeBenchmark, CtSldMidPicoRadius)
   PicoKdTreeCtSldMid<PicoAdaptorX> tree(adaptor, max_leaf_size);
 
   for (auto _ : state) {
-    std::vector<std::pair<Index, Scalar>> results;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> results;
     std::size_t sum = 0;
     for (auto const& p : points_) {
       tree.SearchRadius(p, squared, &results);

--- a/examples/benchmark/benchmark.cpp
+++ b/examples/benchmark/benchmark.cpp
@@ -2,32 +2,31 @@
 
 #include <pico_adaptor.hpp>
 #include <pico_tree/kd_tree.hpp>
-#include <scoped_timer.hpp>
 
 #include "format_bin.hpp"
 #include "nano_adaptor.hpp"
 
 template <int Dim, typename PicoAdaptor>
-using MetricL2 = pico_tree::MetricL2<typename PicoAdaptor::Scalar, Dim>;
+using MetricL2 = pico_tree::MetricL2<typename PicoAdaptor::ScalarType, Dim>;
 
 template <int Dims, typename PicoAdaptor>
 using SplitterLongestMedian = pico_tree::SplitterLongestMedian<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     Dims,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>
 using PicoKdTreeCtSldMid = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     PicoAdaptor::Dim,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>
 using PicoKdTreeCtLngMed = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     PicoAdaptor::Dim,
     PicoAdaptor,
     MetricL2<PicoAdaptor::Dim, PicoAdaptor>,
@@ -35,15 +34,15 @@ using PicoKdTreeCtLngMed = pico_tree::KdTree<
 
 template <typename PicoAdaptor>
 using PicoKdTreeRtSldMid = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     pico_tree::kDynamicDim,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>
 using PicoKdTreeRtLngMed = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     pico_tree::kDynamicDim,
     PicoAdaptor,
     MetricL2<pico_tree::kDynamicDim, PicoAdaptor>,
@@ -51,17 +50,17 @@ using PicoKdTreeRtLngMed = pico_tree::KdTree<
 
 template <typename NanoAdaptor>
 using NanoKdTreeCt = nanoflann::KDTreeSingleIndexAdaptor<
-    nanoflann::L2_Simple_Adaptor<typename NanoAdaptor::Scalar, NanoAdaptor>,
+    nanoflann::L2_Simple_Adaptor<typename NanoAdaptor::ScalarType, NanoAdaptor>,
     NanoAdaptor,
     NanoAdaptor::Dim,
-    typename NanoAdaptor::Index>;
+    typename NanoAdaptor::IndexType>;
 
 template <typename NanoAdaptor>
 using NanoKdTreeRt = nanoflann::KDTreeSingleIndexAdaptor<
-    nanoflann::L2_Simple_Adaptor<typename NanoAdaptor::Scalar, NanoAdaptor>,
+    nanoflann::L2_Simple_Adaptor<typename NanoAdaptor::ScalarType, NanoAdaptor>,
     NanoAdaptor,
     -1,
-    typename NanoAdaptor::Index>;
+    typename NanoAdaptor::IndexType>;
 
 class KdTreeBenchmark : public benchmark::Fixture {
  protected:

--- a/examples/benchmark/nano_adaptor.hpp
+++ b/examples/benchmark/nano_adaptor.hpp
@@ -4,12 +4,15 @@
 #include <point.hpp>
 
 //! Demo point set adaptor for a vector of points.
-template <typename Index_, typename Point_>
+template <typename Index, typename Point>
 class NanoAdaptor {
+ private:
+  using Scalar = typename Point::ScalarType;
+
  public:
-  using Index = Index_;
-  using Point = Point_;
-  using Scalar = typename Point::Scalar;
+  using IndexType = Index;
+  using PointType = Point;
+  using ScalarType = typename Point::ScalarType;
   static constexpr int Dim = Point::Dim;
 
   NanoAdaptor(std::vector<Point> const& points) : points_(points) {}

--- a/examples/eigen/eigen.cpp
+++ b/examples/eigen/eigen.cpp
@@ -78,7 +78,7 @@ void ColMajor() {
         Adaptor(PointsMap(points.data()->data(), Dim, points.size())),
         kMaxLeafCount);
 
-    std::vector<std::pair<Index, Scalar>> knn;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> knn;
     ScopedTimer t("tree nn_ pico_tree deflt l2", kRunCount);
     for (std::size_t i = 0; i < kRunCount; ++i) {
       tree.SearchKnn(p, 1, &knn);
@@ -103,7 +103,7 @@ void RowMajor() {
         Adaptor(PointsMap(points.data()->data(), points.size(), Dim)),
         kMaxLeafCount);
 
-    std::vector<std::pair<Index, Scalar>> knn;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> knn;
     ScopedTimer t("tree nn_ pico_tree deflt l2", kRunCount);
     for (std::size_t i = 0; i < kRunCount; ++i) {
       tree.SearchKnn(p, 1, &knn);
@@ -160,7 +160,7 @@ void Metrics() {
         pico_tree::EigenMetricL2<Scalar>>
         tree(adaptor, kMaxLeafCount);
 
-    std::vector<std::pair<Index, Scalar>> knn;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> knn;
     ScopedTimer t("tree nn_ pico_tree eigen l2", kRunCount);
     for (std::size_t i = 0; i < kRunCount; ++i) {
       tree.SearchKnn(p, 1, &knn);
@@ -176,7 +176,7 @@ void Metrics() {
         pico_tree::EigenMetricL1<Scalar>>
         tree(adaptor, kMaxLeafCount);
 
-    std::vector<std::pair<Index, Scalar>> knn;
+    std::vector<pico_tree::Neighbor<Index, Scalar>> knn;
     ScopedTimer t("tree nn_ pico_tree eigen l1", kRunCount);
     for (std::size_t i = 0; i < kRunCount; ++i) {
       tree.SearchKnn(p, 1, &knn);

--- a/examples/kd_tree/kd_tree.cpp
+++ b/examples/kd_tree/kd_tree.cpp
@@ -4,15 +4,15 @@
 
 template <typename PicoAdaptor>
 using KdTreeCt = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     PicoAdaptor::Dim,
     PicoAdaptor>;
 
 template <typename PicoAdaptor>
 using KdTreeRt = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     pico_tree::kDynamicDim,
     PicoAdaptor>;
 
@@ -20,7 +20,7 @@ using KdTreeRt = pico_tree::KdTree<
 void Build() {
   using PointX = Point2f;
   using Index = int;
-  using Scalar = typename PointX::Scalar;
+  using Scalar = typename PointX::ScalarType;
   using PicoAdaptorX = PicoAdaptor<Index, PointX>;
 
   Index max_leaf_size = 12;
@@ -45,8 +45,8 @@ void Build() {
 template <typename Neighbor>
 class SearchNnCounter {
  private:
-  using Index = typename Neighbor::Index;
-  using Scalar = typename Neighbor::Scalar;
+  using Index = typename Neighbor::IndexType;
+  using Scalar = typename Neighbor::ScalarType;
 
  public:
   //! \brief Creates a visitor for approximate nearest neighbor searching.
@@ -86,7 +86,7 @@ class SearchNnCounter {
 void Search() {
   using PointX = Point3f;
   using Index = int;
-  using Scalar = typename PointX::Scalar;
+  using Scalar = typename PointX::ScalarType;
   using PicoAdaptorX = PicoAdaptor<Index, PointX>;
 
   Index run_count = 1024 * 1024;

--- a/examples/kd_tree/kd_tree.cpp
+++ b/examples/kd_tree/kd_tree.cpp
@@ -146,7 +146,7 @@ void Search() {
   }
 
   SearchNnCounter<pico_tree::Neighbor<Index, Scalar>> v(&nn);
-  tree.SearchNn(q, &v);
+  tree.SearchNearest(q, &v);
 
   std::cout << "Custom visitor # nns considered: " << v.count() << std::endl;
 }

--- a/examples/pico_common/pico_adaptor.hpp
+++ b/examples/pico_common/pico_adaptor.hpp
@@ -10,12 +10,12 @@
 //! inline int sdim() const;
 //! inline Index npts() const;
 //! \endcode
-template <typename Index_, typename Point_>
+template <typename Index, typename Point>
 class PicoAdaptor {
  public:
-  using Index = Index_;
-  using Point = Point_;
-  using Scalar = typename Point::Scalar;
+  using IndexType = Index;
+  using PointType = Point;
+  using ScalarType = typename Point::ScalarType;
   static constexpr int Dim = Point::Dim;
 
   explicit PicoAdaptor(std::vector<Point> const& points) : points_(points) {}

--- a/examples/pico_common/point.hpp
+++ b/examples/pico_common/point.hpp
@@ -12,10 +12,10 @@
 //! \endcode
 //! \tparam Scalar_ Coordinate value type.
 //! \tparam Dim_ The dimension of the space in which the point resides.
-template <typename Scalar_, int Dim_>
+template <typename Scalar, int Dim_>
 class Point {
  public:
-  using Scalar = Scalar_;
+  using ScalarType = Scalar;
   static constexpr int Dim = Dim_;
 
   inline Scalar const& operator()(int const i) const { return data[i]; }
@@ -63,10 +63,10 @@ inline Point GenerateRandomP(typename Point::Scalar size) {
 
 //! Generates \p n points in a square of size \p size .
 template <typename Point>
-std::vector<Point> GenerateRandomN(int n, typename Point::Scalar size) {
+std::vector<Point> GenerateRandomN(int n, typename Point::ScalarType size) {
   std::random_device rd;
   std::mt19937 e2(rd());
-  std::uniform_real_distribution<typename Point::Scalar> dist(0, size);
+  std::uniform_real_distribution<typename Point::ScalarType> dist(0, size);
 
   std::vector<Point> random(n);
   for (auto& p : random) {

--- a/examples/pico_common/point.hpp
+++ b/examples/pico_common/point.hpp
@@ -10,7 +10,7 @@
 //! \code{.cpp}
 //! inline Scalar const& operator()(int i) const;
 //! \endcode
-//! \tparam Scalar_ Coordinate value type.
+//! \tparam Scalar Coordinate value type.
 //! \tparam Dim_ The dimension of the space in which the point resides.
 template <typename Scalar, int Dim_>
 class Point {

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -268,6 +268,7 @@ class ListPool {
     }
   }
 
+  //! \brief Creates an item and returns a pointer to it.
   inline T* Allocate() {
     if (index_ == ChunkSize) {
       Chunk* chunk = new Chunk;
@@ -282,8 +283,10 @@ class ListPool {
     return i;
   }
 
- protected:
+ private:
+  //! \brief The last and currently active chunk.
   Chunk* end_;
+  //! \brief Index within the last chunk.
   std::size_t index_;
 };
 
@@ -297,8 +300,7 @@ class StaticBuffer {
   //! Creates a StaticBuffer having space for \p size elements.
   inline StaticBuffer(std::size_t const size) { buffer_.reserve(size); }
 
-  //! Creates an item and returns a pointer to it. The buffer retains ownership
-  //! of the memory. All memory gets released when the buffer is destroyed.
+  //! \brief Creates an item and returns a pointer to it.
   template <typename... Args>
   inline T* Allocate(Args&&... args) {
     buffer_.emplace_back(std::forward<Args>(args)...);
@@ -306,6 +308,7 @@ class StaticBuffer {
   }
 
  private:
+  //! \private
   std::vector<T> buffer_;
 };
 

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -21,67 +21,6 @@ static constexpr int kDynamicDim = -1;
 
 namespace internal {
 
-//! \brief Restores the heap property of the range defined by \p begin and \p
-//! end, assuming only the top element could have broken it.
-//! \details Worst case performs O(2 log n) comparisons and O(log n) copies.
-//! Performance will be better in practice because it is possible to "early
-//! out" as soon as the first node is encountered that adheres to the heap
-//! property.
-//! <p/>
-//! A function for replacing the top of the heap is not available using the
-//! C++ stl. It is possible to use something like std::make_heap() or
-//! range.push_back() followed by a std::pop_heap() to get the desired effect.
-//! However, these solutions are either forced to traverse the entire range or
-//! introduce overhead, which seem to make them quite a bit slower.
-//! <p/>
-//! It should be possible to use this function in combination with any of the
-//! C++ stl heap related functions, as the documention of those suggest that the
-//! heap is implemented as a binary heap.
-template <typename RandomAccessIterator, typename Compare>
-inline void ReplaceFrontHeap(
-    RandomAccessIterator begin, RandomAccessIterator end, Compare comp) {
-  auto const size = end - begin;
-
-  if (size < 2) {
-    return;
-  }
-
-  typename std::iterator_traits<RandomAccessIterator>::difference_type parent =
-      0;
-  auto front = std::move(begin[parent]);
-  auto const last_parent = (size - 2) / 2;
-  while (parent < last_parent) {
-    auto child = 2 * parent + 1;
-    if (comp(begin[child], begin[child + 1])) {
-      ++child;
-    }
-    if (!comp(front, begin[child])) {
-      begin[parent] = std::move(front);
-      return;
-    } else {
-      begin[parent] = std::move(begin[child]);
-      parent = child;
-    }
-  }
-  // Everything below (but for replacing the last child) is the same as
-  // inside the loop. The only difference is that for even sized vectors we
-  // can't compare with the second child of the last parent.
-  //
-  // Assuming doing the check once outside of the loop is better?
-  if (parent == last_parent) {
-    auto child = 2 * parent + 1;
-    if ((size & 1) == 1 && comp(begin[child], begin[child + 1])) {
-      ++child;
-    }
-    if (comp(front, begin[child])) {
-      begin[parent] = std::move(begin[child]);
-      parent = child;
-    }
-  }
-  // Last child gets replaced.
-  begin[parent] = std::move(front);
-}
-
 //! \brief Inserts \p item in O(n) time at the index for which \p comp
 //! first holds true. The sequence must be sorted and remains sorted after
 //! insertion. The last item in the sequence is "pushed out".

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -24,10 +24,11 @@ static constexpr int kDynamicDim = -1;
 //! another point.
 template <typename Index_, typename Scalar_>
 struct Neighbor {
-  static_assert(std::is_integral<Index_>::value);
+  static_assert(std::is_integral<Index_>::value, "INDEX_NOT_AN_INTEGRAL_TYPE");
   static_assert(
       std::is_integral<Scalar_>::value ||
-      std::is_floating_point<Scalar_>::value);
+          std::is_floating_point<Scalar_>::value,
+      "SCALAR_NOT_AN_INTEGRAL_OR_FLOATING_POINT_TYPE");
 
   //! \brief Index type.
   using Index = Index_;
@@ -110,7 +111,7 @@ struct Dimension<kDynamicDim> {
 template <typename Scalar, int Dim_>
 class Sequence {
  private:
-  static_assert(Dim_ >= 0);
+  static_assert(Dim_ >= 0, "SEQUENCE_DIM_MUST_BE_DYNAMIC_OR_>=_0");
 
  public:
   //! \brief Return type of the Move() member function.

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -40,7 +40,7 @@ struct Neighbor {
   inline constexpr Neighbor() = default;
   //! \brief Constructs a Neighbor given an index and distance.
   inline constexpr Neighbor(Index idx, Scalar dst) noexcept
-      : index(std::forward<Index>(idx)), distance(std::forward<Scalar>(dst)) {}
+      : index(idx), distance(dst) {}
 
   //! \brief Point index of the Neighbor.
   Index index;
@@ -51,7 +51,8 @@ struct Neighbor {
 //! \brief Compares neighbors by distance.
 template <typename Index, typename Scalar>
 inline constexpr bool operator<(
-    Neighbor<Index, Scalar> const& lhs, Neighbor<Index, Scalar> const& rhs) {
+    Neighbor<Index, Scalar> const& lhs,
+    Neighbor<Index, Scalar> const& rhs) noexcept {
   return lhs.distance < rhs.distance;
 }
 
@@ -298,7 +299,9 @@ template <typename T>
 class StaticBuffer {
  public:
   //! Creates a StaticBuffer having space for \p size elements.
-  inline StaticBuffer(std::size_t const size) { buffer_.reserve(size); }
+  inline explicit StaticBuffer(std::size_t const size) {
+    buffer_.reserve(size);
+  }
 
   //! \brief Creates an item and returns a pointer to it.
   template <typename... Args>
@@ -322,7 +325,7 @@ class DynamicBuffer : public ListPool<T, 256> {
   inline DynamicBuffer() = default;
   //! Creates a DynamicBuffer. Ignores the argument in favor of a common
   //! interface with the StaticBuffer.
-  inline DynamicBuffer(std::size_t const) {}
+  inline explicit DynamicBuffer(std::size_t const) {}
 };
 
 //! \brief Returns an std::fstream given a filename.

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -212,43 +212,110 @@ class Sequence<Scalar, kDynamicDim> {
   std::vector<Scalar> sequence_;
 };
 
-//! \brief Simple memory buffer making deletions of recursive elements a bit
-//! easier.
-//! \details The buffer owns all memory returned by MakeItem() and all memory is
-//! released when the buffer is destroyed.
-template <typename Container>
-class MemoryBuffer {
+//! \brief A ListPool is useful for creating objects of a single type when the
+//! total amount to be created cannot be known up front. The list maintains
+//! ownership of the objects which are destructed when the list is destructed.
+//! Objects cannot be returned to the pool.
+//! \details A ListPool maintains a linked list of fixed size chunks that
+//! contain a single object type. The size of the list increases as more objects
+//! are requested.
+//! <p/>
+//! This class supersedes the use of the std::deque. The std::deque appears to
+//! to have different a chunk size depending on the implementation of the C++
+//! standard. This practically means that the performance of PicoTree is
+//! unstable across platforms.
+//! <p/>
+//! Benchmarked various vs. the ListPool using a chunk size 256:
+//! * GCC libstdc++ std::deque ~50% slower.
+//! * Other variations (like the std::list) were about 10% slower.
+//! <p/>
+//! https://en.wikipedia.org/wiki/Memory_pool
+template <typename T, std::size_t ChunkSize>
+class ListPool {
+ private:
+  static_assert(std::is_trivial<T>::value, "TYPE_T_IS_NOT_TRIVIAL");
+  //! \brief List item.
+  struct Chunk {
+    Chunk* prev;
+    T data[ChunkSize];
+  };
+
  public:
+  //! \brief Creates a ListPool using the default constructor.
+  ListPool() : end_(nullptr), index_(ChunkSize) {}
+
+  //! \brief The ListPool class cannot be copied.
+  //! \details The ListPool uses pointers to objects and copying pointers is not
+  //! the same as creating a deep copy. For now we are not interested in
+  //! providing a deep copy.
+  ListPool(ListPool const&) = delete;
+
+  //! \brief ListPool move constructor.
+  ListPool(ListPool&& other) {
+    end_ = other.end_;
+    index_ = other.index_;
+    // So we don't accidentally delete things twice.
+    other.end_ = nullptr;
+  }
+
+  //! \brief Destroys up the ListPool using the destructor.
+  ~ListPool() {
+    // Suppose Chunk was contained by an std::unique_ptr, then it may happen
+    // that we hit a recursion limit depending on how many chunks are
+    // destructed.
+    while (end_ != nullptr) {
+      Chunk* chunk = end_->prev;
+      delete end_;
+      end_ = chunk;
+    }
+  }
+
+  inline T* Allocate() {
+    if (index_ == ChunkSize) {
+      Chunk* chunk = new Chunk;
+      chunk->prev = end_;
+      end_ = chunk;
+      index_ = 0;
+    }
+
+    T* i = &end_->data[index_];
+    index_++;
+
+    return i;
+  }
+
+ protected:
+  Chunk* end_;
+  std::size_t index_;
+};
+
+//! \brief Static MemoryBuffer using a vector. It is a simple memory buffer
+//! making deletions of recursive elements a bit easier.
+//! \details The buffer owns all memory returned by Allocate() and all memory is
+//! released when the buffer is destroyed.
+template <typename T>
+class StaticBuffer {
+ public:
+  //! Creates a StaticBuffer having space for \p size elements.
+  inline StaticBuffer(std::size_t const size) { buffer_.reserve(size); }
+
   //! Creates an item and returns a pointer to it. The buffer retains ownership
   //! of the memory. All memory gets released when the buffer is destroyed.
   template <typename... Args>
-  inline typename Container::value_type* MakeItem(Args&&... args) {
+  inline T* Allocate(Args&&... args) {
     buffer_.emplace_back(std::forward<Args>(args)...);
     return &buffer_.back();
   }
 
- protected:
-  //! Memory buffer.
-  Container buffer_;
+ private:
+  std::vector<T> buffer_;
 };
 
-//! \brief Static MemoryBuffer using a vector.
-//! \details The buffer owns all memory returned by MakeItem() and all memory is
+//! \brief Dynamic MemoryBuffer using a ListPool.
+//! \details The buffer owns all memory returned by Allocate() and all memory is
 //! released when the buffer is destroyed.
 template <typename T>
-class StaticBuffer : public MemoryBuffer<std::vector<T>> {
- public:
-  //! Creates a StaticBuffer having space for \p size elements.
-  inline StaticBuffer(std::size_t const size) {
-    MemoryBuffer<std::vector<T>>::buffer_.reserve(size);
-  }
-};
-
-//! \brief Dynamic MemoryBuffer using a deque.
-//! \details The buffer owns all memory returned by MakeItem() and all memory is
-//! released when the buffer is destroyed.
-template <typename T>
-class DynamicBuffer : public MemoryBuffer<std::deque<T>> {
+class DynamicBuffer : public ListPool<T, 256> {
  public:
   //! Creates a DynamicBuffer.
   inline DynamicBuffer() = default;

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -6,6 +6,7 @@
 //! \brief Contains various common utilities.
 
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <deque>
 #include <fstream>
@@ -101,9 +102,16 @@ struct Dimension<kDynamicDim> {
   inline static int Dim(int dim) { return dim; }
 };
 
-//! \brief Compile time sequence. A lot faster than the run time version.
+//! \brief A sequence stores a contiguous array of elements similar to
+//! std::array or std::vector.
+//! \details The non-specialized Sequence class knows its dimension at
+//! compile-time and uses an std::array for storing its data. Faster than using
+//! the std::vector in practice.
 template <typename Scalar, int Dim_>
 class Sequence {
+ private:
+  static_assert(Dim_ >= 0);
+
  public:
   //! \brief Return type of the Move() member function.
   //! \details An std::array is movable, which is useful if its contents are
@@ -111,7 +119,7 @@ class Sequence {
   //! results in a copy. In some cases we can prevent an unwanted copy.
   using MoveReturnType = Sequence const&;
 
-  //! \details Access data contained in the Sequence.
+  //! \brief Access data contained in the Sequence.
   inline Scalar& operator[](std::size_t const i) noexcept {
     return sequence_[i];
   }
@@ -121,8 +129,21 @@ class Sequence {
     return sequence_[i];
   }
 
+  //! \brief Access data contained in the Sequence.
+  inline Scalar& operator()(std::size_t const i) noexcept {
+    return sequence_[i];
+  }
+
+  //! \brief Access data contained in the Sequence.
+  inline Scalar const& operator()(std::size_t const i) const noexcept {
+    return sequence_[i];
+  }
+
   //! \brief Fills the sequence with value \p v.
-  inline void Fill(std::size_t const, Scalar const v) { sequence_.fill(v); }
+  inline void Fill(std::size_t const s, Scalar const v) {
+    assert(s == static_cast<std::size_t>(Dim_));
+    sequence_.fill(v);
+  }
 
   //! \brief Returns a const reference to the current object.
   inline MoveReturnType Move() const noexcept { return *this; }
@@ -137,7 +158,11 @@ class Sequence {
   std::array<Scalar, Dim_> sequence_;
 };
 
-//! \brief Run time sequence. More flexible than the compile time one.
+//! \brief A sequence stores a contiguous array of elements similar to
+//! std::array or std::vector.
+//! \details The specialized Sequence class doesn't knows its dimension at
+//! compile-time and uses an std::vector for storing its data so it can be
+//! resized.
 template <typename Scalar>
 class Sequence<Scalar, kDynamicDim> {
  public:
@@ -154,6 +179,16 @@ class Sequence<Scalar, kDynamicDim> {
 
   //! \brief Access data contained in the Sequence.
   inline Scalar const& operator[](std::size_t const i) const noexcept {
+    return sequence_[i];
+  }
+
+  //! \brief Access data contained in the Sequence.
+  inline Scalar& operator()(std::size_t const i) noexcept {
+    return sequence_[i];
+  }
+
+  //! \brief Access data contained in the Sequence.
+  inline Scalar const& operator()(std::size_t const i) const noexcept {
     return sequence_[i];
   }
 

--- a/src/pico_tree/core.hpp
+++ b/src/pico_tree/core.hpp
@@ -8,7 +8,6 @@
 #include <array>
 #include <cassert>
 #include <cmath>
-#include <deque>
 #include <fstream>
 #include <vector>
 
@@ -22,18 +21,17 @@ static constexpr int kDynamicDim = -1;
 
 //! \brief A Neighbor is a point reference with a corresponding distance to
 //! another point.
-template <typename Index_, typename Scalar_>
+template <typename Index, typename Scalar>
 struct Neighbor {
-  static_assert(std::is_integral<Index_>::value, "INDEX_NOT_AN_INTEGRAL_TYPE");
+  static_assert(std::is_integral<Index>::value, "INDEX_NOT_AN_INTEGRAL_TYPE");
   static_assert(
-      std::is_integral<Scalar_>::value ||
-          std::is_floating_point<Scalar_>::value,
+      std::is_integral<Scalar>::value || std::is_floating_point<Scalar>::value,
       "SCALAR_NOT_AN_INTEGRAL_OR_FLOATING_POINT_TYPE");
 
   //! \brief Index type.
-  using Index = Index_;
+  using IndexType = Index;
   //! \brief Distance type.
-  using Scalar = Scalar_;
+  using ScalarType = Scalar;
 
   //! \brief Default constructor.
   //! \details Declaring a custom constructor removes the default one. With

--- a/src/pico_tree/eigen.hpp
+++ b/src/pico_tree/eigen.hpp
@@ -9,13 +9,9 @@ template <typename Index, typename Matrix, bool RowMajor>
 class EigenAdaptorBase;
 
 //! \brief ColMajor EigenAdaptor.
-template <typename Index_, typename Matrix>
-class EigenAdaptorBase<Index_, Matrix, false> {
+template <typename Index, typename Matrix>
+class EigenAdaptorBase<Index, Matrix, false> {
  public:
-  //! \brief Index type.
-  using Index = Index_;
-  //! \brief Scalar type.
-  using Scalar = typename Matrix::Scalar;
   //! \brief Spatial dimension. Eigen::Dynamic equals pico_tree::kDynamicDim.
   static constexpr int Dim = Matrix::RowsAtCompileTime;
   //! \brief RowMajor flag that is true if the data is row-major.
@@ -48,13 +44,9 @@ class EigenAdaptorBase<Index_, Matrix, false> {
 };
 
 //! \brief RowMajor EigenAdaptor.
-template <typename Index_, typename Matrix>
-class EigenAdaptorBase<Index_, Matrix, true> {
+template <typename Index, typename Matrix>
+class EigenAdaptorBase<Index, Matrix, true> {
  public:
-  //! \brief Index type.
-  using Index = Index_;
-  //! \brief Scalar type.
-  using Scalar = typename Matrix::Scalar;
   //! \brief Spatial dimension. Eigen::Dynamic equals pico_tree::kDynamicDim.
   static constexpr int Dim = Matrix::ColsAtCompileTime;
   //! \brief RowMajor flag that is true if the data is row-major.
@@ -112,6 +104,11 @@ class EigenAdaptor
       EigenAdaptorBase;
   //! \private
   using internal::EigenAdaptorBase<Index, Matrix, Matrix::IsRowMajor>::matrix_;
+
+  //! \brief Index type.
+  using IndexType = Index;
+  //! \brief Scalar type.
+  using ScalarType = typename Matrix::Scalar;
 
   //! \brief Returns a reference to the Eigen matrix.
   inline Matrix& matrix() { return matrix_; }

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -34,8 +34,8 @@ inline void LongestAxisBox(
 template <typename Neighbor>
 class SearchNn {
  private:
-  using Index = typename Neighbor::Index;
-  using Scalar = typename Neighbor::Scalar;
+  using Index = typename Neighbor::IndexType;
+  using Scalar = typename Neighbor::ScalarType;
 
  public:
   //! \private
@@ -82,8 +82,8 @@ class SearchKnn {
 
   using Neighbor =
       typename std::iterator_traits<RandomAccessIterator>::value_type;
-  using Index = typename Neighbor::Index;
-  using Scalar = typename Neighbor::Scalar;
+  using Index = typename Neighbor::IndexType;
+  using Scalar = typename Neighbor::ScalarType;
 
  public:
   //! \private
@@ -116,8 +116,8 @@ class SearchKnn {
 template <typename Neighbor>
 class SearchRadius {
  private:
-  using Index = typename Neighbor::Index;
-  using Scalar = typename Neighbor::Scalar;
+  using Index = typename Neighbor::IndexType;
+  using Scalar = typename Neighbor::ScalarType;
 
  public:
   //! \private
@@ -168,8 +168,8 @@ class SearchAknn {
 
   using Neighbor =
       typename std::iterator_traits<RandomAccessIterator>::value_type;
-  using Index = typename Neighbor::Index;
-  using Scalar = typename Neighbor::Scalar;
+  using Index = typename Neighbor::IndexType;
+  using Scalar = typename Neighbor::ScalarType;
 
  public:
   //! \private
@@ -445,33 +445,29 @@ class SplitterSlidingMidpoint {
 //! \tparam Dim The spatial dimension of the tree. It can be set to
 //! pico_tree::kDynamicDim in case Dim is only known at run-time.
 template <
-    typename Index_,
-    typename Scalar_,
+    typename Index,
+    typename Scalar,
     int Dim_,
-    typename Points_,
-    typename Metric_ = MetricL2<Scalar_, Dim_>,
-    typename Splitter_ =
-        SplitterSlidingMidpoint<Index_, Scalar_, Dim_, Points_>>
+    typename Points,
+    typename Metric = MetricL2<Scalar, Dim_>,
+    typename Splitter = SplitterSlidingMidpoint<Index, Scalar, Dim_, Points>>
 class KdTree {
  public:
   //! \brief Index type.
-  using Index = Index_;
+  using IndexType = Index;
   //! \brief Scalar type.
-  using Scalar = Scalar_;
+  using ScalarType = Scalar;
   //! \brief KdTree dimension. It equals pico_tree::kDynamicDim in case Dim is
   //! only known at run-time.
   static constexpr int Dim = Dim_;
   //! \brief Point set or adaptor type.
-  using Points = Points_;
+  using PointsType = Points;
   //! \brief The metric used for various searches.
-  using Metric = Metric_;
+  using MetricType = Metric;
   //! \brief Neighbor type of various search resuls.
-  using Neighbor = struct Neighbor<Index, Scalar>;
+  using NeighborType = Neighbor<Index, Scalar>;
 
  private:
-  //! \private
-  using Splitter = Splitter_;
-
   //! \brief KdTree Node.
   struct Node {
     //! \brief Data is used to either store branch or leaf information. Which
@@ -631,8 +627,8 @@ class KdTree {
   //! \details Interpretation of the output distance depends on the Metric. The
   //! default MetricL2 results in a squared distance.
   template <typename P>
-  inline void SearchNn(P const& p, Neighbor* nn) const {
-    internal::SearchNn<Neighbor> v(nn);
+  inline void SearchNn(P const& p, NeighborType* nn) const {
+    internal::SearchNn<NeighborType> v(nn);
     SearchNearest(root_, p, &v);
   }
 
@@ -649,7 +645,7 @@ class KdTree {
     static_assert(
         std::is_same<
             typename std::iterator_traits<RandomAccessIterator>::value_type,
-            Neighbor>::value,
+            NeighborType>::value,
         "SEARCH_ITERATOR_VALUE_TYPE_DOES_NOT_EQUAL_NEIGHBOR_INDEX_SCALAR");
 
     internal::SearchKnn<RandomAccessIterator> v(begin, end);
@@ -663,7 +659,7 @@ class KdTree {
   //! const&, RandomAccessIterator, RandomAccessIterator) const
   template <typename P>
   inline void SearchKnn(
-      P const& p, Index const k, std::vector<Neighbor>* knn) const {
+      P const& p, Index const k, std::vector<NeighborType>* knn) const {
     // If it happens that the point set has less points than k we just return
     // all points in the set.
     knn->resize(std::min(k, points_.npts()));
@@ -691,9 +687,9 @@ class KdTree {
   inline void SearchRadius(
       P const& p,
       Scalar const radius,
-      std::vector<Neighbor>* n,
+      std::vector<NeighborType>* n,
       bool const sort = false) const {
-    internal::SearchRadius<Neighbor> v(radius, n);
+    internal::SearchRadius<NeighborType> v(radius, n);
     SearchNearest(root_, p, &v);
 
     if (sort) {
@@ -743,7 +739,7 @@ class KdTree {
     static_assert(
         std::is_same<
             typename std::iterator_traits<RandomAccessIterator>::value_type,
-            Neighbor>::value,
+            NeighborType>::value,
         "SEARCH_ITERATOR_VALUE_TYPE_DOES_NOT_EQUAL_NEIGHBOR_INDEX_SCALAR");
 
     internal::SearchAknn<RandomAccessIterator> v(e, begin, end);
@@ -760,7 +756,7 @@ class KdTree {
       P const& p,
       Index const k,
       Scalar const e,
-      std::vector<Neighbor>* knn) const {
+      std::vector<NeighborType>* knn) const {
     // If it happens that the point set has less points than k we just return
     // all points in the set.
     knn->resize(std::min(k, points_.npts()));

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -623,8 +623,8 @@ class KdTree {
   //! \see internal::SearchRadius
   //! \see internal::SearchAknn
   template <typename P, typename V>
-  inline void SearchNn(P const& p, V* visitor) const {
-    SearchNn(root_, p, visitor);
+  inline void SearchNearest(P const& p, V* visitor) const {
+    SearchNearest(root_, p, visitor);
   }
 
   //! \brief Searches for the nearest neighbor of point \p p .
@@ -633,7 +633,7 @@ class KdTree {
   template <typename P>
   inline void SearchNn(P const& p, Neighbor* nn) const {
     internal::SearchNn<Neighbor> v(nn);
-    SearchNn(root_, p, &v);
+    SearchNearest(root_, p, &v);
   }
 
   //! \brief Searches for the k nearest neighbors of point \p p , where k equals
@@ -653,7 +653,7 @@ class KdTree {
         "SEARCH_ITERATOR_VALUE_TYPE_DOES_NOT_EQUAL_NEIGHBOR_INDEX_SCALAR");
 
     internal::SearchKnn<RandomAccessIterator> v(begin, end);
-    SearchNn(root_, p, &v);
+    SearchNearest(root_, p, &v);
   }
 
   //! \brief Searches for the \p k nearest neighbors of point \p p and stores
@@ -694,7 +694,7 @@ class KdTree {
       std::vector<Neighbor>* n,
       bool const sort = false) const {
     internal::SearchRadius<Neighbor> v(radius, n);
-    SearchNn(root_, p, &v);
+    SearchNearest(root_, p, &v);
 
     if (sort) {
       v.Sort();
@@ -747,7 +747,7 @@ class KdTree {
         "SEARCH_ITERATOR_VALUE_TYPE_DOES_NOT_EQUAL_NEIGHBOR_INDEX_SCALAR");
 
     internal::SearchAknn<RandomAccessIterator> v(e, begin, end);
-    SearchNn(root_, p, &v);
+    SearchNearest(root_, p, &v);
   }
 
   //! \brief Searches for the \p k approximate nearest neighbors of point \p p
@@ -869,10 +869,11 @@ class KdTree {
         0, 0, points_.npts(), Sequence(root_box_min_), Sequence(root_box_max_));
   }
 
-  //! Returns the nearest neighbor (or neighbors) of point \p p depending on
-  //! their selection by visitor \p visitor for node \p node .
+  //! \brief Returns the nearest neighbor (or neighbors) of point \p p depending
+  //! on their selection by visitor \p visitor for node \p node .
   template <typename P, typename V>
-  inline void SearchNn(Node const* const node, P const& p, V* visitor) const {
+  inline void SearchNearest(
+      Node const* const node, P const& p, V* visitor) const {
     if (node->IsLeaf()) {
       for (Index i = node->data.leaf.begin_idx; i < node->data.leaf.end_idx;
            ++i) {
@@ -900,9 +901,9 @@ class KdTree {
         node_2nd = node->left;
       }
 
-      SearchNn(node_1st, p, visitor);
+      SearchNearest(node_1st, p, visitor);
       if (visitor->max() >= metric_(node->data.branch.split_val, v)) {
-        SearchNn(node_2nd, p, visitor);
+        SearchNearest(node_2nd, p, visitor);
       }
     }
   }

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -579,8 +579,9 @@ class KdTree {
 
  public:
   //! \brief The KdTree cannot be copied.
-  //! \details The KdTree uses pointers to refer to tree nodes. These would all
-  //! be invalidated during a deep copy.
+  //! \details The KdTree uses pointers to nodes and copying pointers is not
+  //! the same as creating a deep copy. For now we are not interested in
+  //! providing a deep copy.
   //! \private
   KdTree(KdTree const&) = delete;
 

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -529,7 +529,7 @@ class KdTree {
         Index const size,
         typename Sequence::MoveReturnType box_min,
         typename Sequence::MoveReturnType box_max) const {
-      Node* node = nodes_.MakeItem();
+      Node* node = nodes_.Allocate();
       //
       if (size <= max_leaf_size_) {
         node->data.leaf.begin_idx = offset;

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -466,7 +466,7 @@ class KdTree {
   //! \brief The metric used for various searches.
   using Metric = Metric_;
   //! \brief Neighbor type of various search resuls.
-  using Neighbor = Neighbor<Index, Scalar>;
+  using Neighbor = struct Neighbor<Index, Scalar>;
 
  private:
   //! \private

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -446,14 +446,33 @@ class SplitterSlidingMidpoint {
 //! \tparam Dim The spatial dimension of the tree. It can be set to
 //! pico_tree::kDynamicDim in case Dim is only known at run-time.
 template <
-    typename Index,
-    typename Scalar,
-    int Dim,
-    typename Points,
-    typename Metric = MetricL2<Scalar, Dim>,
-    typename Splitter = SplitterSlidingMidpoint<Index, Scalar, Dim, Points>>
+    typename Index_,
+    typename Scalar_,
+    int Dim_,
+    typename Points_,
+    typename Metric_ = MetricL2<Scalar_, Dim_>,
+    typename Splitter_ =
+        SplitterSlidingMidpoint<Index_, Scalar_, Dim_, Points_>>
 class KdTree {
+ public:
+  //! \brief Index type.
+  using Index = Index_;
+  //! \brief Scalar type.
+  using Scalar = Scalar_;
+  //! \brief KdTree dimension. It equals pico_tree::kDynamicDim in case Dim is
+  //! only known at run-time.
+  static constexpr int Dim = Dim_;
+  //! \brief Point set or adaptor type.
+  using Points = Points_;
+  //! \brief The metric used for various searches.
+  using Metric = Metric_;
+  //! \brief Neighbor type of various search resuls.
+  using Neighbor = Neighbor<Index, Scalar>;
+
  private:
+  //! \private
+  using Splitter = Splitter_;
+
   //! \brief KdTree Node.
   struct Node {
     //! \brief Data is used to either store branch or leaf information. Which
@@ -558,8 +577,6 @@ class KdTree {
     Splitter const& splitter_;
     MemoryBuffer& nodes_;
   };
-
-  using Neighbor = Neighbor<Index, Scalar>;
 
  public:
   //! \brief The KdTree cannot be copied.

--- a/src/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/kd_tree.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cassert>
 #include <numeric>
 
 #include "core.hpp"
@@ -910,24 +909,10 @@ class KdTree {
 
   //! Checks if \p p is contained in the box defined by \p min and \p max. A
   //! point on the edge considered inside the box.
-  template <typename P>
-  inline bool PointInBox(Sequence const& p, P const& min, P const& max) const {
+  template <typename P0, typename P1>
+  inline bool PointInBox(P0 const& p, P1 const& min, P1 const& max) const {
     for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
-      if (min(i) > p[i] || max(i) < p[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  //! Checks if the point refered to by \p idx is contained in the box defined
-  //! by \p min and \p max. A point on the edge considered inside the box.
-  template <typename P>
-  inline bool PointInBox(Index const idx, P const& min, P const& max) const {
-    auto const& p = points_(idx);
-    for (int i = 0; i < internal::Dimension<Dim>::Dim(points_.sdim()); ++i) {
-      Scalar const v = p(i);
-      if (min(i) > v || max(i) < v) {
+      if (min(i) > p(i) || max(i) < p(i)) {
         return false;
       }
     }
@@ -966,7 +951,7 @@ class KdTree {
       for (Index i = node->data.leaf.begin_idx; i < node->data.leaf.end_idx;
            ++i) {
         Index const idx = indices_[i];
-        if (PointInBox(idx, rng_min, rng_max)) {
+        if (PointInBox(points_(idx), rng_min, rng_max)) {
           idxs->push_back(idx);
         }
       }

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -27,11 +27,11 @@ void SearchKnn(
 template <typename Tree>
 void TestBox(
     Tree const& tree,
-    typename Tree::Scalar const min_v,
-    typename Tree::Scalar const max_v) {
-  using PointsX = typename Tree::Points;
-  using PointX = typename PointsX::Point;
-  using Index = typename PointsX::Index;
+    typename Tree::ScalarType const min_v,
+    typename Tree::ScalarType const max_v) {
+  using PointsX = typename Tree::PointsType;
+  using PointX = typename PointsX::PointType;
+  using Index = typename PointsX::IndexType;
 
   auto const& points = tree.points();
 
@@ -70,11 +70,11 @@ void TestBox(
 }
 
 template <typename Tree>
-void TestRadius(Tree const& tree, typename Tree::Scalar const radius) {
-  using PointsX = typename Tree::Points;
-  using PointX = typename PointsX::Point;
-  using Index = typename PointsX::Index;
-  using Scalar = typename PointsX::Scalar;
+void TestRadius(Tree const& tree, typename Tree::ScalarType const radius) {
+  using PointsX = typename Tree::PointsType;
+  using PointX = typename PointsX::PointType;
+  using Index = typename PointsX::IndexType;
+  using Scalar = typename PointsX::ScalarType;
 
   auto const& points = tree.points();
 
@@ -107,11 +107,11 @@ void TestRadius(Tree const& tree, typename Tree::Scalar const radius) {
 }
 
 template <typename Tree>
-void TestKnn(Tree const& tree, typename Tree::Index const k) {
-  using PointsX = typename Tree::Points;
-  using PointX = typename PointsX::Point;
-  using Index = typename PointsX::Index;
-  using Scalar = typename PointsX::Scalar;
+void TestKnn(Tree const& tree, typename Tree::IndexType const k) {
+  using PointsX = typename Tree::PointsType;
+  using PointX = typename PointsX::PointType;
+  using Index = typename PointsX::IndexType;
+  using Scalar = typename PointsX::ScalarType;
 
   auto const& points = tree.points();
 

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -1,17 +1,5 @@
 #pragma once
 
-template <typename Tree>
-using TreeIndexType = typename std::remove_reference<decltype(
-    std::declval<Tree>().points())>::type::Index;
-
-template <typename Tree>
-using TreeScalarType = typename std::remove_reference<decltype(
-    std::declval<Tree>().points())>::type::Scalar;
-
-template <typename Tree>
-using TreePointsType = typename std::remove_reference<decltype(
-    std::declval<Tree>().points())>::type;
-
 template <
     typename P,
     typename Points,
@@ -36,14 +24,12 @@ void SearchKnn(
   std::sort(knn->begin(), knn->end());
 }
 
-// TODO Perhaps do something more friendly for exposing types.
-// TODO Some traits.
 template <typename Tree>
 void TestBox(
     Tree const& tree,
-    TreeScalarType<Tree> const min_v,
-    TreeScalarType<Tree> const max_v) {
-  using PointsX = TreePointsType<Tree>;
+    typename Tree::Scalar const min_v,
+    typename Tree::Scalar const max_v) {
+  using PointsX = typename Tree::Points;
   using PointX = typename PointsX::Point;
   using Index = typename PointsX::Index;
 
@@ -84,8 +70,8 @@ void TestBox(
 }
 
 template <typename Tree>
-void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
-  using PointsX = TreePointsType<Tree>;
+void TestRadius(Tree const& tree, typename Tree::Scalar const radius) {
+  using PointsX = typename Tree::Points;
   using PointX = typename PointsX::Point;
   using Index = typename PointsX::Index;
   using Scalar = typename PointsX::Scalar;
@@ -121,8 +107,8 @@ void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
 }
 
 template <typename Tree>
-void TestKnn(Tree const& tree, TreeIndexType<Tree> const k) {
-  using PointsX = TreePointsType<Tree>;
+void TestKnn(Tree const& tree, typename Tree::Index const k) {
+  using PointsX = typename Tree::Points;
   using PointX = typename PointsX::Point;
   using Index = typename PointsX::Index;
   using Scalar = typename PointsX::Scalar;

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -23,7 +23,7 @@ void SearchKnn(
     Points const& points,
     Index const k,
     Metric const& metric,
-    std::vector<std::pair<Index, Scalar>>* knn) {
+    std::vector<pico_tree::Neighbor<Index, Scalar>>* knn) {
   Index const npts = points.npts();
   knn->resize(static_cast<std::size_t>(npts));
   for (Index i = 0; i < npts; ++i) {
@@ -31,16 +31,9 @@ void SearchKnn(
   }
 
   Index const max_k = std::min(k, npts);
-  std::nth_element(
-      knn->begin(),
-      knn->begin() + (max_k - 1),
-      knn->end(),
-      pico_tree::internal::NeighborComparator<Index, Scalar>());
+  std::nth_element(knn->begin(), knn->begin() + (max_k - 1), knn->end());
   knn->resize(static_cast<std::size_t>(max_k));
-  std::sort(
-      knn->begin(),
-      knn->end(),
-      pico_tree::internal::NeighborComparator<Index, Scalar>());
+  std::sort(knn->begin(), knn->end());
 }
 
 // TODO Perhaps do something more friendly for exposing types.
@@ -108,12 +101,12 @@ void TestRadius(Tree const& tree, TreeScalarType<Tree> const radius) {
 
   auto const& metric = tree.metric();
   Scalar const lp_radius = metric(radius);
-  std::vector<std::pair<Index, Scalar>> results;
+  std::vector<pico_tree::Neighbor<Index, Scalar>> results;
   tree.SearchRadius(p, lp_radius, &results);
 
   for (auto const& r : results) {
-    EXPECT_LE(metric(p, points(r.first)), lp_radius);
-    EXPECT_EQ(metric(p, points(r.first)), r.second);
+    EXPECT_LE(metric(p, points(r.index)), lp_radius);
+    EXPECT_EQ(metric(p, points(r.index)), r.distance);
   }
 
   std::size_t count = 0;
@@ -145,23 +138,23 @@ void TestKnn(Tree const& tree, TreeIndexType<Tree> const k) {
 
   Scalar ratio = tree.metric()(1.5);
 
-  std::vector<std::pair<Index, Scalar>> results_exact;
-  std::vector<std::pair<Index, Scalar>> results_apprx;
+  std::vector<pico_tree::Neighbor<Index, Scalar>> results_exact;
+  std::vector<pico_tree::Neighbor<Index, Scalar>> results_apprx;
   tree.SearchKnn(p, k, &results_exact);
   tree.SearchAknn(p, k, ratio, &results_apprx);
 
-  std::vector<std::pair<Index, Scalar>> compare;
+  std::vector<pico_tree::Neighbor<Index, Scalar>> compare;
   SearchKnn(p, points, k, tree.metric(), &compare);
 
   ASSERT_EQ(compare.size(), results_exact.size());
   for (std::size_t i = 0; i < compare.size(); ++i) {
     // Index is not tested in case it happens points have an equal distance.
     // TODO Would be nicer to test indices too.
-    EXPECT_FLOAT_EQ(results_exact[i].second, compare[i].second);
+    EXPECT_FLOAT_EQ(results_exact[i].distance, compare[i].distance);
 
     // Because results_apprx[i] is already scaled: approx = approx / ratio, the
     // check below is the same as: approx <= exact * ratio
     EXPECT_PRED_FORMAT2(
-        testing::FloatLE, results_apprx[i].second, results_exact[i].second);
+        testing::FloatLE, results_apprx[i].distance, results_exact[i].distance);
   }
 }

--- a/test/kd_tree_test.cpp
+++ b/test/kd_tree_test.cpp
@@ -8,15 +8,15 @@
 
 template <typename PicoAdaptor>
 using KdTree = pico_tree::KdTree<
-    typename PicoAdaptor::Index,
-    typename PicoAdaptor::Scalar,
+    typename PicoAdaptor::IndexType,
+    typename PicoAdaptor::ScalarType,
     PicoAdaptor::Dim,
     PicoAdaptor>;
 
 TEST(KdTreeTest, MetricL1) {
   using PointX = Point2f;
   using Index = int;
-  using Scalar = typename PointX::Scalar;
+  using Scalar = typename PointX::ScalarType;
   using AdaptorX = PicoAdaptor<Index, PointX>;
   constexpr auto Dim = PointX::Dim;
   std::vector<PointX> points{{2.0f, 4.0f}};
@@ -33,7 +33,7 @@ TEST(KdTreeTest, MetricL1) {
 TEST(KdTreeTest, MetricL2) {
   using PointX = Point2f;
   using Index = int;
-  using Scalar = typename PointX::Scalar;
+  using Scalar = typename PointX::ScalarType;
   using AdaptorX = PicoAdaptor<Index, PointX>;
   constexpr auto Dim = PointX::Dim;
   std::vector<PointX> points{{2.0f, 4.0f}};
@@ -50,7 +50,7 @@ TEST(KdTreeTest, MetricL2) {
 TEST(KdTreeTest, SplitterMedian) {
   using PointX = Point2f;
   using Index = int;
-  using Scalar = typename PointX::Scalar;
+  using Scalar = typename PointX::ScalarType;
   using AdaptorX = PicoAdaptor<Index, PointX>;
   constexpr auto Dim = PointX::Dim;
   std::vector<PointX> pts4{
@@ -106,7 +106,7 @@ TEST(KdTreeTest, SplitterMedian) {
 TEST(KdTreeTest, SplitterSlidingMidpoint) {
   using PointX = Point2f;
   using Index = int;
-  using Scalar = typename PointX::Scalar;
+  using Scalar = typename PointX::ScalarType;
   using AdaptorX = PicoAdaptor<Index, PointX>;
   constexpr auto Dim = PointX::Dim;
   std::vector<PointX> pts4{{0.0, 2.0}, {0.0, 1.0}, {0.0, 4.0}, {0.0, 3.0}};
@@ -174,9 +174,9 @@ namespace {
 template <typename PointX>
 void QueryRange(
     int const point_count,
-    typename PointX::Scalar const area_size,
-    typename PointX::Scalar const min_v,
-    typename PointX::Scalar const max_v) {
+    typename PointX::ScalarType const area_size,
+    typename PointX::ScalarType const min_v,
+    typename PointX::ScalarType const max_v) {
   using Index = int;
   using AdaptorX = PicoAdaptor<Index, PointX>;
   std::vector<PointX> random = GenerateRandomN<PointX>(point_count, area_size);
@@ -189,8 +189,8 @@ void QueryRange(
 template <typename PointX>
 void QueryRadius(
     int const point_count,
-    typename PointX::Scalar const area_size,
-    typename PointX::Scalar const radius) {
+    typename PointX::ScalarType const area_size,
+    typename PointX::ScalarType const radius) {
   using Index = int;
   using AdaptorX = PicoAdaptor<Index, PointX>;
   std::vector<PointX> random = GenerateRandomN<PointX>(point_count, area_size);
@@ -203,7 +203,7 @@ void QueryRadius(
 template <typename PointX>
 void QueryKnn(
     int const point_count,
-    typename PointX::Scalar const area_size,
+    typename PointX::ScalarType const area_size,
     int const k) {
   using Index = int;
   using AdaptorX = PicoAdaptor<Index, PointX>;


### PR DESCRIPTION
Changes:
* Replaced std::pair<> with pico_tree::Neighbor<>.
  * Better readability of the type itself and its variables (first, second vs. index, distance).
  * std::pair<> is not a POD type or trivially copyable. This practically means it can't be easily mapped to memory (such as with pybind11).
* Added various typedefs (usings) to the public interface of the KdTree: IndexType, ScalarType, PointsType, etc. Updated the examples to follow the same typedef style.
* Replaced the std::deque based dynamic memory manager with a custom ListPool one. 
  * At the time of writing, the performance of using an std::deque can vary quite a bit across implementations of the C++ standard. This is because (at least in part) the internal chunk sizes differ quite a bit.
  * Benchmarking on the Würzburg marketplace dataset shows that the new ListPool gives a small overall performance improvement of about 2-3%.
* Renamed the custom visitor version of SearchNn to SearchNearest to disambiguate it from the SearchNn that looks for a single nearest neighbor.