### PR TITLE
Topological space

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ $ pip install ./pico_tree --install-option="-GMinGW Makefiles"
 * S. Maneewongvatana and D. M. Mount. [It's okay to be skinny, if your friends are fat.](http://www.cs.umd.edu/~mount/Papers/cgc99-smpack.pdf) 4th Annual CGC Workshop on Computational Geometry, 1999.
 * S. Arya and H. Y. Fu. [Expected-case complexity of approximate nearest neighbor searching.](https://www.cse.ust.hk/faculty/arya/pub/exp.pdf) InProceedings of the 11th ACM-SIAM Symposium on Discrete Algorithms, 2000.
 * S. Arya and D. M. Mount. [Algorithms for fast vector quantization.](https://www.cs.umd.edu/~mount/Papers/DCC.pdf) In IEEE Data Compression Conference, pages 381–390, March 1993.
-* https://en.wikipedia.org/wiki/K-d_tree
+* A. Yershova and S. M. LaValle, [Improving Motion-Planning Algorithms by Efficient Nearest-Neighbor Searching.](http://msl.cs.uiuc.edu/~lavalle/papers/YerLav06.pdf) In IEEE Transactions on Robotics, vol. 23, no. 1, pp. 151-157, Feb. 2007.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available under the [MIT](https://en.wikipedia.org/wiki/MIT_License) license.
 * KdTree
   * Nearest neighbors, approximate nearest neighbors, radius, and box searches.
   * Customizable nearest neighbor searches, [metrics](https://en.wikipedia.org/wiki/Metric_(mathematics)) and tree splitting techniques.
-  * Support for topological spaces with identifications. E.g., points on a circle represented by the interval [-pi, pi].
+  * Support for topological spaces with identifications. E.g., points on a circle represented by the interval `[-pi, pi]`.
   * Compile time and run time known dimensions.
   * Static tree builds.
   * Thread safe queries.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Available under the [MIT](https://en.wikipedia.org/wiki/MIT_License) license.
 * KdTree
   * Nearest neighbors, approximate nearest neighbors, radius, and box searches.
   * Customizable nearest neighbor searches, [metrics](https://en.wikipedia.org/wiki/Metric_(mathematics)) and tree splitting techniques.
+  * Support for topological spaces with identifications. E.g., points on a circle represented by the interval [-pi, pi].
   * Compile time and run time known dimensions.
   * Static tree builds.
   * Thread safe queries.

--- a/examples/kd_tree/kd_tree.cpp
+++ b/examples/kd_tree/kd_tree.cpp
@@ -86,7 +86,7 @@ class SearchNnCounter {
 };
 
 // Different search options.
-void Search() {
+void Search3d() {
   using PointX = Point3f;
   using Index = int;
   using Scalar = typename PointX::ScalarType;
@@ -154,8 +154,32 @@ void Search() {
   std::cout << "Custom visitor # nns considered: " << v.count() << std::endl;
 }
 
+// Search on the circle.
+void SearchS1() {
+  using PointX = Point1f;
+  using TraitsX = pico_tree::StdTraits<std::vector<PointX>>;
+  using NeighborX =
+      pico_tree::KdTree<TraitsX, pico_tree::SO2<TraitsX>>::NeighborType;
+
+  const auto pi = typename PointX::ScalarType(3.1415926537);
+
+  pico_tree::KdTree<TraitsX, pico_tree::SO2<TraitsX>> tree(
+      GenerateRandomN<PointX>(512, -pi, pi), 10);
+
+  std::array<NeighborX, 8> knn;
+  tree.SearchKnn(PointX{pi}, knn.begin(), knn.end());
+
+  // These prints show that wrapping around near point -PI ~ PI is supported.
+  std::cout << "Closest angles (index, distance, value): " << std::endl;
+  for (auto const& nn : knn) {
+    std::cout << "  " << nn.index << ", " << nn.distance << ", "
+              << tree.points()[nn.index] << std::endl;
+  }
+}
+
 int main() {
   BasicVector();
-  Search();
+  Search3d();
+  SearchS1();
   return 0;
 }

--- a/examples/pico_toolshed/pico_toolshed/point.hpp
+++ b/examples/pico_toolshed/pico_toolshed/point.hpp
@@ -78,10 +78,11 @@ using Point3d = Point<double, 3>;
 
 //! Generates \p n points in a square of size \p size .
 template <typename Point>
-std::vector<Point> GenerateRandomN(int n, typename Point::ScalarType size) {
+inline std::vector<Point> GenerateRandomN(
+    int n, typename Point::ScalarType min, typename Point::ScalarType max) {
   std::random_device rd;
   std::mt19937 e2(rd());
-  std::uniform_real_distribution<typename Point::ScalarType> dist(0, size);
+  std::uniform_real_distribution<typename Point::ScalarType> dist(min, max);
 
   std::vector<Point> random(n);
   for (auto& p : random) {
@@ -91,4 +92,10 @@ std::vector<Point> GenerateRandomN(int n, typename Point::ScalarType size) {
   }
 
   return random;
+}
+
+template <typename Point>
+inline std::vector<Point> GenerateRandomN(
+    int n, typename Point::ScalarType size) {
+  return GenerateRandomN<Point>(n, typename Point::ScalarType(0.0), size);
 }

--- a/src/pico_tree/pico_tree/eigen.hpp
+++ b/src/pico_tree/pico_tree/eigen.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 
+#include "metric.hpp"
 #include "std_traits.hpp"
 
 namespace pico_tree {
@@ -320,6 +321,9 @@ struct StdPointTraits<Eigen::Map<
 template <typename Scalar>
 class EigenL1 {
  public:
+  //! \brief This tag specifies the supported space by this metric.
+  using SpaceTag = EuclideanSpaceTag;
+
   //! \brief Calculates the distance between points \p p0 and \p p1.
   template <typename Derived0, typename Derived1>
   inline Scalar operator()(
@@ -342,6 +346,9 @@ class EigenL1 {
 template <typename Scalar>
 class EigenL2Squared {
  public:
+  //! \brief This tag specifies the supported space by this metric.
+  using SpaceTag = EuclideanSpaceTag;
+
   //! \brief Calculates the distance between points \p p0 and \p p1.
   template <typename Derived0, typename Derived1>
   inline Scalar operator()(

--- a/src/pico_tree/pico_tree/internal/memory.hpp
+++ b/src/pico_tree/pico_tree/internal/memory.hpp
@@ -35,6 +35,8 @@ class ListPool {
   };
 
  public:
+  using ValueType = T;
+
   //! \brief Creates a ListPool using the default constructor.
   ListPool() : end_(nullptr), index_(ChunkSize) {}
 
@@ -93,6 +95,8 @@ class ListPool {
 template <typename T>
 class StaticBuffer {
  public:
+  using ValueType = T;
+
   //! Creates a StaticBuffer having space for \p size elements.
   inline explicit StaticBuffer(std::size_t const size) {
     buffer_.reserve(size);
@@ -116,6 +120,8 @@ class StaticBuffer {
 template <typename T>
 class DynamicBuffer : public ListPool<T, 256> {
  public:
+  using ValueType = typename ListPool<T, 256>::ValueType;
+
   //! Creates a DynamicBuffer.
   inline DynamicBuffer() = default;
   //! Creates a DynamicBuffer. Ignores the argument in favor of a common

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -970,6 +970,10 @@ class KdTree {
       typename Sequence::MoveReturnType box_min,
       typename Sequence::MoveReturnType box_max,
       std::vector<Index>* idxs) const {
+    // TODO Perhaps we can support it for both topological and Euclidean spaces.
+    static_assert(
+        std::is_same<typename Metric::SpaceTag, EuclideanSpaceTag>::value,
+        "SEARCH_BOX_ONLY_SUPPORTED_FOR_EUCLIDEAN_SPACES");
     if (node->IsLeaf()) {
       for (Index i = node->data.leaf.begin_idx; i < node->data.leaf.end_idx;
            ++i) {

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -99,7 +99,6 @@ class Builder {
   using Scalar = typename Traits::ScalarType;
   using Node = typename SpaceTagTraits<SpaceTag>::template Node<Index, Scalar>;
   using MemoryBuffer = typename Splitter::template MemoryBuffer<Node>;
-  using SequenceType = Sequence<Scalar, Dim_>;
 
   inline Builder(
       Index const max_leaf_size, Splitter const& splitter, MemoryBuffer* nodes)
@@ -112,8 +111,8 @@ class Builder {
       Index const depth,
       Index const offset,
       Index const size,
-      typename SequenceType::MoveReturnType box_min,
-      typename SequenceType::MoveReturnType box_max) const {
+      typename Sequence<Scalar, Dim_>::MoveReturnType box_min,
+      typename Sequence<Scalar, Dim_>::MoveReturnType box_max) const {
     Node* node = nodes_.Allocate();
     //
     if (size <= max_leaf_size_) {
@@ -141,10 +140,10 @@ class Builder {
       Index const left_size = split_idx - offset;
       Index const right_size = size - left_size;
 
-      SequenceType left_box_max = box_max;
+      Sequence<Scalar, Dim_> left_box_max = box_max;
       left_box_max[node->data.branch.split_dim] = node->data.branch.split_val;
 
-      SequenceType right_box_min = box_min;
+      Sequence<Scalar, Dim_> right_box_min = box_min;
       right_box_min[node->data.branch.split_dim] = node->data.branch.split_val;
 
       node->left = SplitIndices(
@@ -162,8 +161,8 @@ class Builder {
 
  private:
   inline void SetBranch(
-      SequenceType const& box_min,
-      SequenceType const& box_max,
+      Sequence<Scalar, Dim_> const& box_min,
+      Sequence<Scalar, Dim_> const& box_max,
       int const& split_dim,
       Scalar const& split_val,
       NodeEuclidean<Index, Scalar>* node) const {
@@ -172,8 +171,8 @@ class Builder {
   }
 
   inline void SetBranch(
-      SequenceType const& box_min,
-      SequenceType const& box_max,
+      Sequence<Scalar, Dim_> const& box_min,
+      Sequence<Scalar, Dim_> const& box_max,
       int const& split_dim,
       Scalar const& split_val,
       NodeTopological<Index, Scalar>* node) const {
@@ -199,7 +198,6 @@ class SearchNearestEuclidean {
   using Index = typename Traits::IndexType;
   using Scalar = typename Traits::ScalarType;
   using Space = typename Traits::SpaceType;
-  using Sequence = Sequence<Scalar, Dim_>;
 
  public:
   using Node = NodeEuclidean<Index, Scalar>;
@@ -282,7 +280,7 @@ class SearchNearestEuclidean {
   Metric const& metric_;
   std::vector<Index> const& indices_;
   Point const& point_;
-  Sequence node_box_offset_;
+  Sequence<Scalar, Dim_> node_box_offset_;
   Visitor* visitor_;
 };
 

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -43,9 +43,9 @@ struct KdTreeBranchSplit {
 };
 
 //! \brief Tree branch.
-//! \details This branch version allows topological identies (wrapping around)
-//! by storing the boundaries of the box that corresponds to the current node.
-//! The split value allows arbitrary splitting techniques.
+//! \details This branch version allows identifications (wrapping around) by
+//! storing the boundaries of the box that corresponds to the current node. The
+//! split value allows arbitrary splitting techniques.
 template <typename Scalar>
 struct KdTreeBranchRange {
   //! \brief Split coordinate / index of the KdTree spatial dimension.

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -312,12 +312,12 @@ inline void LongestAxisBox(
 //! \details A version of the median of medians algorithm. The tree is build in
 //! O(n log n) time on average.
 //!
-//! Although it builds the tree slower compared to using
-//! SplitterSlidingMidpoint, it will query a single nearest neighbor faster.
-//! Faster queries can offset the extra build costs in scenarios such as ICP.
-//!
-//! Note that this splitter is not recommended when searching for more than a
-//! single neighbor.
+//! This splitting technique is generally slower compared to
+//! SplitterSlidingMidpoint but results in a balanced KdTree. In case the same
+//! point cloud is both used for building the tree and querying it, this
+//! technique could possibly be used for faster single nearest neighbor queries
+//! as compared to SplitterSlidingMidpoint. However, this is only useful when
+//! querying many (2n-4n) times as the build time of the tree is still slower.
 template <typename Traits>
 class SplitterLongestMedian {
  private:
@@ -373,17 +373,17 @@ class SplitterLongestMedian {
   std::vector<Index>& indices_;
 };
 
-//! \brief Splits a tree node halfway the longest axis of the bounding box that
-//! contains it.
+//! \brief Bounding boxes of tree nodes are split in the middle along the
+//! longest axis unless this results in an empty sub-node. In this case the
+//! split gets adjusted to fit a single point into this sub-node.
 //! \details Based on the paper "It's okay to be skinny, if your friends are
 //! fat". The aspect ratio of the split is at most 2:1 unless that results in an
-//! empty leaf. Then at least one point is moved into the empty leaf and the
-//! split is adjusted.
+//! empty sub-node.
 //!
 //! * http://www.cs.umd.edu/~mount/Papers/cgc99-smpack.pdf
 //!
-//! The tree is build in O(n log n) time and tree creation is faster than using
-//! SplitterLongestMedian.
+//! The tree is build in O(n log n) time and results in a tree that is both
+//! faster to build and query as compared to SplitterLongestMedian.
 //!
 //! This splitter can be used to answer an approximate nearest neighbor query in
 //! O(1/e^d log n) time.

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -873,13 +873,11 @@ class KdTree {
     stream->Read(&is_leaf);
 
     if (is_leaf) {
-      stream->Read(&node->data.leaf.begin_idx);
-      stream->Read(&node->data.leaf.end_idx);
+      stream->Read(&node->data.leaf);
       node->left = nullptr;
       node->right = nullptr;
     } else {
-      stream->Read(&node->data.branch.split_dim);
-      stream->Read(&node->data.branch.split_val);
+      stream->Read(&node->data.branch);
       node->left = ReadNode(stream);
       node->right = ReadNode(stream);
     }
@@ -892,12 +890,10 @@ class KdTree {
       Node const* const node, internal::Stream* stream) const {
     if (node->IsLeaf()) {
       stream->Write(true);
-      stream->Write(node->data.leaf.begin_idx);
-      stream->Write(node->data.leaf.end_idx);
+      stream->Write(node->data.leaf);
     } else {
       stream->Write(false);
-      stream->Write(node->data.branch.split_dim);
-      stream->Write(node->data.branch.split_val);
+      stream->Write(node->data.branch);
       WriteNode(node->left, stream);
       WriteNode(node->right, stream);
     }

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -167,8 +167,8 @@ class KdTreeBuilder {
 
  private:
   inline void SetBranch(
-      Sequence<Scalar, Dim_> const& box_min,
-      Sequence<Scalar, Dim_> const& box_max,
+      Sequence<Scalar, Dim_> const&,
+      Sequence<Scalar, Dim_> const&,
       int const& split_dim,
       Scalar const& split_val,
       KdTreeNodeEuclidean<Index, Scalar>* node) const {

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -99,7 +99,7 @@ class Builder {
   using Scalar = typename Traits::ScalarType;
   using Node = typename SpaceTagTraits<SpaceTag>::template Node<Index, Scalar>;
   using MemoryBuffer = typename Splitter::template MemoryBuffer<Node>;
-  using Sequence = Sequence<Scalar, Dim_>;
+  using SequenceType = Sequence<Scalar, Dim_>;
 
   inline Builder(
       Index const max_leaf_size, Splitter const& splitter, MemoryBuffer* nodes)
@@ -112,8 +112,8 @@ class Builder {
       Index const depth,
       Index const offset,
       Index const size,
-      typename Sequence::MoveReturnType box_min,
-      typename Sequence::MoveReturnType box_max) const {
+      typename SequenceType::MoveReturnType box_min,
+      typename SequenceType::MoveReturnType box_max) const {
     Node* node = nodes_.Allocate();
     //
     if (size <= max_leaf_size_) {
@@ -141,10 +141,10 @@ class Builder {
       Index const left_size = split_idx - offset;
       Index const right_size = size - left_size;
 
-      Sequence left_box_max = box_max;
+      SequenceType left_box_max = box_max;
       left_box_max[node->data.branch.split_dim] = node->data.branch.split_val;
 
-      Sequence right_box_min = box_min;
+      SequenceType right_box_min = box_min;
       right_box_min[node->data.branch.split_dim] = node->data.branch.split_val;
 
       node->left = SplitIndices(
@@ -162,8 +162,8 @@ class Builder {
 
  private:
   inline void SetBranch(
-      Sequence const& box_min,
-      Sequence const& box_max,
+      SequenceType const& box_min,
+      SequenceType const& box_max,
       int const& split_dim,
       Scalar const& split_val,
       NodeEuclidean<Index, Scalar>* node) const {
@@ -172,8 +172,8 @@ class Builder {
   }
 
   inline void SetBranch(
-      Sequence const& box_min,
-      Sequence const& box_max,
+      SequenceType const& box_min,
+      SequenceType const& box_max,
       int const& split_dim,
       Scalar const& split_val,
       NodeTopological<Index, Scalar>* node) const {

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -97,7 +97,7 @@ class Builder {
  public:
   using Index = typename Traits::IndexType;
   using Scalar = typename Traits::ScalarType;
-  using Node = typename SpaceTagTraits<SpaceTag>::Node<Index, Scalar>;
+  using Node = typename SpaceTagTraits<SpaceTag>::template Node<Index, Scalar>;
   using MemoryBuffer = typename Splitter::template MemoryBuffer<Node>;
   using Sequence = Sequence<Scalar, Dim_>;
 

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -23,35 +23,57 @@ struct NodeBase {
   Derived* right;
 };
 
+//! \brief Tree leaf.
+template <typename Index>
+struct Leaf {
+  //! \private
+  Index begin_idx;
+  //! \private
+  Index end_idx;
+};
+
+//! \brief Tree branch.
+template <typename Scalar>
+struct BranchSplit {
+  //! \brief Split coordinate / index of the KdTree spatial dimension.
+  int split_dim;
+  //! \brief Coordinate value used for splitting the children of a node.
+  Scalar split_val;
+};
+
+//! \brief Tree branch.
+template <typename Scalar>
+struct BranchRange {
+  //! \brief Split coordinate / index of the KdTree spatial dimension.
+  int split_dim;
+  //! \brief Coordinate value used for splitting the children of a node.
+  Scalar split_val;
+  //! \brief Min box value of this node for split_dim.
+  Scalar min_val;
+  //! \brief Max box value of this node for split_dim.
+  Scalar max_val;
+};
+
+//! \brief Data is used to either store branch or leaf information. Which
+//! union member is used can be tested with IsBranch() or IsLeaf().
+template <typename Leaf, typename Branch>
+union NodeData {
+  //! \brief Union branch data.
+  Branch branch;
+  //! \brief Union leaf data.
+  Leaf leaf;
+};
+
 //! \brief KdTree Node.
 template <typename Index, typename Scalar>
 struct NodeEuclidean : public NodeBase<NodeEuclidean<Index, Scalar>> {
-  //! \brief Data is used to either store branch or leaf information. Which
-  //! union member is used can be tested with IsBranch() or IsLeaf().
-  union Data {
-    //! \brief Tree branch.
-    struct Branch {
-      //! \brief Split coordinate / index of the KdTree spatial dimension.
-      int split_dim;
-      //! \brief Coordinate value used for splitting the children of a node.
-      Scalar split_val;
-    };
+  NodeData<Leaf<Index>, BranchSplit<Scalar>> data;
+};
 
-    //! \brief Tree leaf.
-    struct Leaf {
-      //! \private
-      Index begin_idx;
-      //! \private
-      Index end_idx;
-    };
-
-    //! \brief Union branch data.
-    Branch branch;
-    //! \brief Union leaf data.
-    Leaf leaf;
-  };
-
-  Data data;
+//! \brief KdTree Node.
+template <typename Index, typename Scalar>
+struct NodeTopological : public NodeBase<NodeEuclidean<Index, Scalar>> {
+  NodeData<Leaf<Index>, BranchRange<Scalar>> data;
 };
 
 //! KdTree builder.

--- a/src/pico_tree/pico_tree/metric.hpp
+++ b/src/pico_tree/pico_tree/metric.hpp
@@ -53,6 +53,17 @@ struct Sum {
 
 }  // namespace internal
 
+//! \brief Identifies a metric to support the most generic space that can be
+//! used with PicoTree's search structures.
+//! \details A space tag is used by PicoTree to select the most optimal
+//! algorithms for use with a particular space.
+class TopologicalSpaceTag {};
+
+//! \brief Identifies a metric to support the Euclidean space with PicoTree's
+//! search structures.
+//! \see TopologicalSpaceTag
+class EuclideanSpaceTag : public TopologicalSpaceTag {};
+
 //! \brief L1 metric for measuring the Taxicab or Manhattan distance between
 //! points.
 //! \details For more details:
@@ -64,6 +75,9 @@ class L1 {
   using Scalar = typename Traits::ScalarType;
 
  public:
+  //! \brief This tag specifies the supported space by this metric.
+  using SpaceTag = EuclideanSpaceTag;
+
   //! \brief Calculates the distance between points \p p0 and \p p1.
   //! \tparam P0 Point type.
   //! \tparam P1 Point type.
@@ -98,6 +112,9 @@ class L2Squared {
   using Scalar = typename Traits::ScalarType;
 
  public:
+  //! \brief This tag specifies the supported space by this metric.
+  using SpaceTag = EuclideanSpaceTag;
+
   //! \brief Calculates the distance between points \p p0 and \p p1.
   //! \tparam P0 Point type.
   //! \tparam P1 Point type.

--- a/src/pico_tree/pico_tree/metric.hpp
+++ b/src/pico_tree/pico_tree/metric.hpp
@@ -61,10 +61,17 @@ struct Sum {
 //! used with PicoTree's search structures.
 //! \details A space tag is used by PicoTree to select the most optimal
 //! algorithms for use with a particular space.
+//!
+//! Usings the TopologicalSpaceTag for metrics allows support for
+//! identifications in point sets. A practical example is that of the unit
+//! circle represented by the interval [-PI, PI]. Here, -PI and PI are the same
+//! point on the circle and performing a radius query around both values should
+//! result in the same point set.
 class TopologicalSpaceTag {};
 
 //! \brief Identifies a metric to support the Euclidean space with PicoTree's
 //! search structures.
+//! \details Supports the fastest queries doesn't support identificatons.
 //! \see TopologicalSpaceTag
 class EuclideanSpaceTag : public TopologicalSpaceTag {};
 
@@ -146,8 +153,10 @@ class L2Squared {
 
 //! \brief The SO2 metric measures distances on the unit circle S1. It is the
 //! intrinsic metric of points in R2 on S1 given by the great-circel distance.
-//! \details Named after the Special Orthogonal Group of dimension 2. For more
-//! details:
+//! \details Named after the Special Orthogonal Group of dimension 2. The circle
+//! S1 is represented by the range [-PI, PI] / -PI ~ PI.
+//!
+//! For more details:
 //! * https://en.wikipedia.org/wiki/Intrinsic_metric
 //! * https://en.wikipedia.org/wiki/Great-circle_distance
 template <typename Traits>
@@ -178,12 +187,12 @@ class SO2 {
     return operator()(*Traits::PointCoords(p0), *Traits::PointCoords(p1));
   }
 
-  //! \brief Calculates the distance between x and the rectangle defined by
-  //! [min, max].
+  //! \brief Calculates the distance between x and the box defined by [min,
+  //! max].
   inline Scalar operator()(
       Scalar const x, Scalar const min, Scalar const max) const {
-    // Rectangles currently can't be around the identity of PI ~ -PI where the
-    // minimum is larger than he maximum.
+    // Rectangles currently can't be around the identification of PI ~ -PI where
+    // the minimum is larger than he maximum.
     if (x < min || x > max) {
       return std::min(operator()(x, min), operator()(x, max));
     }

--- a/test/pico_tree/common.hpp
+++ b/test/pico_tree/common.hpp
@@ -149,15 +149,15 @@ void TestRadius(Tree const& tree, typename Tree::ScalarType const radius) {
   EXPECT_EQ(count, results.size());
 }
 
-template <typename Tree>
-void TestKnn(Tree const& tree, typename Tree::IndexType const k) {
+template <typename Tree, typename Point>
+void TestKnn(
+    Tree const& tree, typename Tree::IndexType const k, Point const& p) {
   using TraitsX = typename Tree::TraitsType;
   using Index = typename Tree::IndexType;
   using Scalar = typename Tree::ScalarType;
 
   // The data doesn't have to be by reference_wrapper, but that prevents a copy.
   auto const points = tree.points();
-  auto const p = TraitsX::PointAt(points, TraitsX::SpaceNpts(points) / 2);
   Scalar ratio = tree.metric()(Scalar(1.5));
 
   std::vector<pico_tree::Neighbor<Index, Scalar>> results_exact;
@@ -177,4 +177,13 @@ void TestKnn(Tree const& tree, typename Tree::IndexType const k) {
     // the check below is the same as: approx <= exact * ratio
     FloatLe(results_apprx[i].distance, results_exact[i].distance);
   }
+}
+
+template <typename Tree>
+void TestKnn(Tree const& tree, typename Tree::IndexType const k) {
+  using TraitsX = typename Tree::TraitsType;
+
+  auto const points = tree.points();
+  auto const p = TraitsX::PointAt(points, TraitsX::SpaceNpts(points) / 2);
+  TestKnn(tree, k, p);
 }

--- a/test/pico_tree/kd_tree_test.cpp
+++ b/test/pico_tree/kd_tree_test.cpp
@@ -199,17 +199,11 @@ TEST(KdTreeTest, QueryKnn10) { QueryKnn<Point2f>(1024 * 1024, 100.0f, 10); }
 TEST(KdTreeTest, QuerySo2Knn4) {
   using PointX = Point1f;
   using TraitsX = Traits<Space<PointX>>;
-  std::vector<PointX> random = GenerateRandomN<PointX>(
-      256 * 256,
-      typename KdTree<PointX>::ScalarType(-pico_tree::internal::kPi),
-      typename KdTree<PointX>::ScalarType(pico_tree::internal::kPi));
 
+  const auto pi = typename KdTree<PointX>::ScalarType(pico_tree::internal::kPi);
+  std::vector<PointX> random = GenerateRandomN<PointX>(256 * 256, -pi, pi);
   pico_tree::KdTree<TraitsX, pico_tree::SO2<TraitsX>> tree(random, 10);
-
-  TestKnn(
-      tree,
-      static_cast<typename KdTree<PointX>::IndexType>(8),
-      PointX{typename KdTree<PointX>::ScalarType(pico_tree::internal::kPi)});
+  TestKnn(tree, static_cast<typename KdTree<PointX>::IndexType>(8), PointX{pi});
 }
 
 TEST(KdTreeTest, WriteRead) {

--- a/test/pico_tree/kd_tree_test.cpp
+++ b/test/pico_tree/kd_tree_test.cpp
@@ -196,6 +196,19 @@ TEST(KdTreeTest, QueryKnn1) { QueryKnn<Point2f>(1024 * 1024, 100.0f, 1); }
 
 TEST(KdTreeTest, QueryKnn10) { QueryKnn<Point2f>(1024 * 1024, 100.0f, 10); }
 
+TEST(KdTreeTest, QuerySo2Knn4) {
+  using PointX = Point1f;
+  using TraitsX = Traits<Space<PointX>>;
+  std::vector<PointX> random = GenerateRandomN<PointX>(
+      256 * 256,
+      typename KdTree<PointX>::ScalarType(-pico_tree::internal::kPi),
+      typename KdTree<PointX>::ScalarType(pico_tree::internal::kPi));
+
+  pico_tree::KdTree<TraitsX, pico_tree::SO2<TraitsX>> tree(random, 10);
+
+  TestKnn(tree, static_cast<typename KdTree<PointX>::IndexType>(4));
+}
+
 TEST(KdTreeTest, WriteRead) {
   using Index = int;
   using Scalar = typename Point2f::ScalarType;

--- a/test/pico_tree/kd_tree_test.cpp
+++ b/test/pico_tree/kd_tree_test.cpp
@@ -206,7 +206,10 @@ TEST(KdTreeTest, QuerySo2Knn4) {
 
   pico_tree::KdTree<TraitsX, pico_tree::SO2<TraitsX>> tree(random, 10);
 
-  TestKnn(tree, static_cast<typename KdTree<PointX>::IndexType>(4));
+  TestKnn(
+      tree,
+      static_cast<typename KdTree<PointX>::IndexType>(8),
+      PointX{typename KdTree<PointX>::ScalarType(pico_tree::internal::kPi)});
 }
 
 TEST(KdTreeTest, WriteRead) {

--- a/test/pico_tree/metric_test.cpp
+++ b/test/pico_tree/metric_test.cpp
@@ -40,3 +40,17 @@ TEST(MetricTest, L2Squared) {
   EXPECT_FLOAT_EQ(metric(-3.1f, 8.9f), 144.0f);
   EXPECT_FLOAT_EQ(metric(-3.1f), 9.61f);
 }
+
+TEST(MetricTest, SO2) {
+  PointX p0{1.0f};
+  PointX p1{1.1f};
+
+  pico_tree::SO2<TraitsX> metric;
+
+  EXPECT_FLOAT_EQ(metric(p0, p1), 0.1f);
+  EXPECT_FLOAT_EQ(metric(-0.1f), 0.1f);
+  EXPECT_TRUE(metric(-3.14f, 3.14f) < 0.1f);
+  EXPECT_FLOAT_EQ(metric(-0.1f, -0.3f, -0.2f), metric(-0.1f, -0.2f));
+  EXPECT_FLOAT_EQ(metric(-0.4f, -0.3f, -0.2f), metric(-0.4f, -0.3f));
+  EXPECT_FLOAT_EQ(metric(-0.25f, -0.3f, -0.2f), 0.0f);
+}


### PR DESCRIPTION
Added support for topological spaces with identifications. This allows KdTree searches to support manifolds such as circles or cylinders that "wrap around" near points that can be expressed with different sets of coordinate values. 

Changes:
* Metrics now require a SpaceTag. A SpaceTag identifies which type of space is supported.
* Support for two different SearchNearest algorithms. Selection is based on the SpaceTag of the metric.
* Metrics belonging to topological spaces require an extra method (see SO2 metric).
* Added the `SO2` metric that can be used to search for points on a circle.
* Updated examples and unit tests.
* SearchNearest queries (for Euclidean spaces) have become 1-2% faster (reduced search arguments).