### PR TITLE
Memory

### DIFF
--- a/examples/pico_understory/pico_understory/cover_tree.hpp
+++ b/examples/pico_understory/pico_understory/cover_tree.hpp
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <numeric>
-#include <pico_tree/internal/memory.hpp>
 #include <pico_tree/internal/search_visitor.hpp>
 #include <random>
 
@@ -29,6 +28,37 @@
 #define SIMPLIFIED_NEAREST_ANCESTOR_COVER_TREE
 
 namespace pico_tree {
+
+namespace internal {
+
+//! \brief Static MemoryBuffer using a vector. It is a simple memory buffer
+//! making deletions of recursive elements a bit easier.
+//! \details The buffer owns all memory returned by Allocate() and all memory is
+//! released when the buffer is destroyed.
+template <typename T>
+class StaticBuffer {
+ public:
+  //! \brief Type allocated and stored by the buffer.
+  using ValueType = T;
+
+  //! Creates a StaticBuffer having space for \p size elements.
+  inline explicit StaticBuffer(std::size_t const size) {
+    buffer_.reserve(size);
+  }
+
+  //! \brief Creates an item and returns a pointer to it.
+  template <typename... Args>
+  inline T* Allocate(Args&&... args) {
+    buffer_.emplace_back(std::forward<Args>(args)...);
+    return &buffer_.back();
+  }
+
+ private:
+  //! \private
+  std::vector<T> buffer_;
+};
+
+}  // namespace internal
 
 template <typename Traits, typename Metric = L2<Traits>>
 class CoverTree {

--- a/src/pico_tree/pico_tree/internal/memory.hpp
+++ b/src/pico_tree/pico_tree/internal/memory.hpp
@@ -103,7 +103,7 @@ class ChunkAllocator final {
   using Chunk = typename Resource::Chunk;
 
  public:
-  //! \brief Value type allocated by the ListPoolResource.
+  //! \brief Value type allocated by the ChunkAllocator.
   using ValueType = T;
 
   //! \brief ChunkAllocator constructor.

--- a/src/pico_tree/pico_tree/internal/memory.hpp
+++ b/src/pico_tree/pico_tree/internal/memory.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include <type_traits>
 
 namespace pico_tree {
 
@@ -101,49 +101,6 @@ class ListPool {
   Chunk* end_;
   //! \brief Index within the last chunk.
   std::size_t index_;
-};
-
-//! \brief Static MemoryBuffer using a vector. It is a simple memory buffer
-//! making deletions of recursive elements a bit easier.
-//! \details The buffer owns all memory returned by Allocate() and all memory is
-//! released when the buffer is destroyed.
-template <typename T>
-class StaticBuffer {
- public:
-  //! \brief Type allocated and stored by the buffer.
-  using ValueType = T;
-
-  //! Creates a StaticBuffer having space for \p size elements.
-  inline explicit StaticBuffer(std::size_t const size) {
-    buffer_.reserve(size);
-  }
-
-  //! \brief Creates an item and returns a pointer to it.
-  template <typename... Args>
-  inline T* Allocate(Args&&... args) {
-    buffer_.emplace_back(std::forward<Args>(args)...);
-    return &buffer_.back();
-  }
-
- private:
-  //! \private
-  std::vector<T> buffer_;
-};
-
-//! \brief Dynamic MemoryBuffer using a ListPool.
-//! \details The buffer owns all memory returned by Allocate() and all memory is
-//! released when the buffer is destroyed.
-template <typename T, std::size_t ChunkSize = 256>
-class DynamicBuffer : public ListPool<T, ChunkSize> {
- public:
-  //! \brief Type allocated and stored by the buffer.
-  using ValueType = typename ListPool<T, ChunkSize>::ValueType;
-
-  //! \brief Creates a DynamicBuffer.
-  inline DynamicBuffer() = default;
-  //! \brief Creates a DynamicBuffer. Ignores the argument in favor of a common
-  //! interface with the StaticBuffer.
-  inline explicit DynamicBuffer(std::size_t const) {}
 };
 
 }  // namespace internal

--- a/src/pico_tree/pico_tree/internal/memory.hpp
+++ b/src/pico_tree/pico_tree/internal/memory.hpp
@@ -6,101 +6,113 @@ namespace pico_tree {
 
 namespace internal {
 
-//! \brief A ListPool is useful for creating objects of a single type when the
-//! total amount to be created cannot be known up front. The list maintains
-//! ownership of the objects which are destructed when the list is destructed.
-//! Objects cannot be returned to the pool.
-//! \details A ListPool maintains a linked list of fixed size chunks that
-//! contain a single object type. The size of the list increases as more objects
-//! are requested.
+//! \brief An instance of ListPoolResource constructs fixed size chunks of
+//! memory and stores these in a list. Memory is only released when the resource
+//! is destructed or when calling the Release() method.
+//! \details A ListPoolResource is mainly useful for monotonically constructing
+//! objects of a single type when the total amount to be created cannot be known
+//! up front.
 //! <p/>
-//! This class supersedes the use of the std::deque. The std::deque appears to
-//! to have different a chunk size depending on the implementation of the C++
-//! standard. This practically means that the performance of PicoTree is
-//! unstable across platforms.
-//! <p/>
-//! Benchmarked various vs. the ListPool using a chunk size 256:
-//! * GCC libstdc++ std::deque ~50% slower.
-//! * Other variations (like the std::list) were about 10% slower.
+//! A previous memory manager implementation was based on the std::deque. The
+//! chunk size that it uses can vary across different implementations of the C++
+//! standard, resulting in an unreliable performance of PicoTree.
 //! <p/>
 //! https://en.wikipedia.org/wiki/Memory_pool
 template <typename T, std::size_t ChunkSize>
-class ListPool {
+class ListPoolResource {
  private:
   static_assert(std::is_trivial<T>::value, "TYPE_T_IS_NOT_TRIVIAL");
   static_assert(
       std::is_trivially_destructible<T>::value,
       "TYPE_T_IS_NOT_TRIVIALLY_DESTRUCTIBLE");
-  //! \brief List item.
+
+  //! \brief Chunk of memory.
   struct Chunk {
     Chunk* prev;
-    T data[ChunkSize];
+    std::array<T, ChunkSize> data;
   };
 
  public:
-  //! \brief Type allocated and stored by the ListPool.
+  //! \brief Type allocated by the ListPoolResource.
   using ValueType = T;
 
-  //! \brief Creates a ListPool using the default constructor.
-  ListPool() : end_(nullptr), index_(ChunkSize) {}
+  //! \brief ListPoolResource constructor.
+  ListPoolResource() : head_(nullptr) {}
 
-  //! \brief A ListPool instance cannot be copied.
-  //! \details The default copy constructor would just copy the pointer owned by
-  //! the ListPool. Also, a ListPool provides pointers to objects. Creating new
-  //! objects would invalidate those pointers.
-  ListPool(ListPool const&) = delete;
+  //! \brief A ListPoolResource instance cannot be copied.
+  //! \details Just no!
+  ListPoolResource(ListPoolResource const&) = delete;
 
-  //! \brief ListPool move constructor.
-  ListPool(ListPool&& other) {
-    end_ = other.end_;
-    index_ = other.index_;
+  //! \private
+  ListPoolResource(ListPoolResource&& other) : head_(other.head_) {
     // So we don't accidentally delete things twice.
-    other.end_ = nullptr;
+    other.head_ = nullptr;
   }
 
-  //! \brief A ListPool instance cannot be copied.
-  ListPool& operator=(ListPool const& other) = delete;
+  //! \private
+  ListPoolResource& operator=(ListPoolResource const& other) = delete;
 
-  //! \brief ListPool move assignment.
-  ListPool& operator=(ListPool&& other) {
-    end_ = other.end_;
-    index_ = other.index_;
-    other.end_ = nullptr;
+  //! \private
+  ListPoolResource& operator=(ListPoolResource&& other) {
+    head_ = other.head_;
+    other.head_ = nullptr;
     return *this;
   }
 
-  //! \brief Destroys up the ListPool using the destructor.
-  ~ListPool() {
+  //! \brief ListPoolResource destructor.
+  virtual ~ListPoolResource() { Release(); }
+
+  //! \brief Allocates a chunk of memory and returns a pointer to it.
+  inline std::array<T, ChunkSize>* Allocate() {
+    Chunk* chunk = new Chunk;
+    chunk->prev = head_;
+    head_ = chunk;
+    return &head_->data;
+  }
+
+  //! \brief Release all memory allocated by this ListPoolResource.
+  void Release() {
     // Suppose Chunk was contained by an std::unique_ptr, then it may happen
     // that we hit a recursion limit depending on how many chunks are
     // destructed.
-    while (end_ != nullptr) {
-      Chunk* chunk = end_->prev;
-      delete end_;
-      end_ = chunk;
+    while (head_ != nullptr) {
+      Chunk* chunk = head_->prev;
+      delete head_;
+      head_ = chunk;
     }
-  }
-
-  //! \brief Creates an item and returns a pointer to it.
-  inline T* Allocate() {
-    if (index_ == ChunkSize) {
-      Chunk* chunk = new Chunk;
-      chunk->prev = end_;
-      end_ = chunk;
-      index_ = 0;
-    }
-
-    T* i = &end_->data[index_];
-    index_++;
-
-    return i;
   }
 
  private:
-  //! \brief The last and currently active chunk.
-  Chunk* end_;
-  //! \brief Index within the last chunk.
-  std::size_t index_;
+  Chunk* head_;
+};
+
+//! \brief An instance of ChunkAllocator constructs objects. It does so in
+//! chunks of size ChunkSize to reduce memory fragmentation.
+template <typename T, std::size_t ChunkSize>
+class ChunkAllocator final {
+ public:
+  //! \brief Type allocated by the ChunkAllocator.
+  using ValueType = T;
+
+  ChunkAllocator() : object_index_(ChunkSize) {}
+
+  //! \brief Create an object of type T and return a pointer to it.
+  inline T* Allocate() {
+    if (object_index_ == ChunkSize) {
+      chunk_ = resource_.Allocate();
+      object_index_ = 0;
+    }
+
+    T* object = &(*chunk_)[object_index_];
+    object_index_++;
+
+    return object;
+  }
+
+ private:
+  ListPoolResource<T, ChunkSize> resource_;
+  std::size_t object_index_;
+  std::array<T, ChunkSize>* chunk_;
 };
 
 }  // namespace internal

--- a/src/pico_tree/pico_tree/kd_tree.hpp
+++ b/src/pico_tree/pico_tree/kd_tree.hpp
@@ -124,7 +124,7 @@ struct KdTreeData {
 
   using NodeType = Node_;
 
-  using NodeAllocatorType = ListPool<NodeType, 256>;
+  using NodeAllocatorType = ChunkAllocator<NodeType, 256>;
 
  private:
   //! \brief Recursively reads the Node and its descendants.

--- a/test/pico_tree/kd_tree_test.cpp
+++ b/test/pico_tree/kd_tree_test.cpp
@@ -23,7 +23,7 @@ class DynamicSpace {
   DynamicSpace(std::vector<Point> const& space, int sdim)
       : space_(space), sdim_(sdim) {}
 
-  inline operator std::vector<Point> const &() const { return space_; }
+  inline operator std::vector<Point> const&() const { return space_; }
 
   int sdim() const { return sdim_; }
 
@@ -195,12 +195,14 @@ void QueryKnn(
     typename PointX::ScalarType const area_size,
     int const k) {
   std::vector<PointX> random = GenerateRandomN<PointX>(point_count, area_size);
-  KdTree<PointX> tree(random, 8);
+  KdTree<PointX> tree1(random, 8);
 
-  // This line compile time "tests" the move capability of the tree.
-  auto tree2 = std::move(tree);
+  // "Test" move constructor.
+  auto tree2 = std::move(tree1);
+  // "Test" move assignment.
+  tree1 = std::move(tree2);
 
-  TestKnn(tree2, static_cast<typename KdTree<PointX>::IndexType>(k));
+  TestKnn(tree1, static_cast<typename KdTree<PointX>::IndexType>(k));
 }
 
 }  // namespace


### PR DESCRIPTION
The introduced changes make memory management simpler:
* Removed StaticBuffer and DynamicBuffer (the latter an alias of ListPool).
* Split ListPool into ListPoolResource and ChunkAllocator.

Consequences: 
* SplitterLongestMedian is no longer able to use the static node allocator. SplitterLongestMedian dependent build and query times didn't really seem to be impacted.
* Memory management is no longer dependent on the KdTree splitting technique. Simplifies related future work.
* Save and Load of KdTree slightly simplified.