### PR TITLE
Build updated to use iterators instead of indices.

### DIFF
--- a/test/pico_tree/kd_tree_test.cpp
+++ b/test/pico_tree/kd_tree_test.cpp
@@ -62,15 +62,15 @@ TEST(KdTreeTest, SplitterMedian) {
   box.min(1) = 0.0f;
   box.max(0) = 1.0f;
   box.max(1) = 0.0f;
+  std::vector<Index>::iterator split;
   std::size_t split_dim;
-  Index split_idx;
   Scalar split_val;
 
-  SplitterX splitter4(spcx4, &idx4);
-  splitter4(0, 0, 4, box, &split_dim, &split_idx, &split_val);
+  SplitterX splitter4(spcx4);
+  splitter4(0, idx4.begin(), idx4.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx4.begin(), 2);
   EXPECT_EQ(split_dim, 0);
-  EXPECT_EQ(split_idx, 2);
   EXPECT_EQ(split_val, ptsx4[2](0));
 
   std::vector<PointX> ptsx7{
@@ -84,18 +84,19 @@ TEST(KdTreeTest, SplitterMedian) {
   SpaceX spcx7(ptsx7);
   std::vector<Index> idx7{0, 1, 2, 3, 4, 5, 6};
 
-  SplitterX splitter7(spcx7, &idx7);
-  splitter7(0, 0, 7, box, &split_dim, &split_idx, &split_val);
+  SplitterX splitter7(spcx7);
+  splitter7(0, idx7.begin(), idx7.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx7.begin(), 3);
   EXPECT_EQ(split_dim, 0);
-  EXPECT_EQ(split_idx, 3);
   EXPECT_EQ(split_val, ptsx7[idx7[3]](0));
 
   box.max(1) = 10.0f;
-  splitter7(1, 3, 4, box, &split_dim, &split_idx, &split_val);
+  splitter7(
+      1, idx7.begin() + 3, idx7.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx7.begin(), 5);
   EXPECT_EQ(split_dim, 1);
-  EXPECT_EQ(split_idx, 5);
   EXPECT_EQ(split_val, ptsx7[idx7[5]](1));
 }
 
@@ -110,11 +111,11 @@ TEST(KdTreeTest, SplitterSlidingMidpoint) {
   SpaceX spcx4(ptsx4);
   std::vector<Index> idx4{0, 1, 2, 3};
 
-  SplitterX splitter(spcx4, &idx4);
+  SplitterX splitter(spcx4);
 
   pico_tree::internal::Box<Scalar, 2> box(2);
+  std::vector<Index>::iterator split;
   std::size_t split_dim;
-  Index split_idx;
   Scalar split_val;
 
   // Everything is forced to the right leaf. This means we want a single point
@@ -124,10 +125,10 @@ TEST(KdTreeTest, SplitterSlidingMidpoint) {
   box.min(1) = Scalar{0.0};
   box.max(0) = Scalar{0.0};
   box.max(1) = Scalar{1.0};
-  splitter(0, 0, 4, box, &split_dim, &split_idx, &split_val);
+  splitter(0, idx4.begin(), idx4.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx4.begin(), 1);
   EXPECT_EQ(split_dim, 1);
-  EXPECT_EQ(split_idx, 1);
   EXPECT_EQ(split_val, ptsx4[0](1));
   EXPECT_EQ(idx4[0], 1);
   EXPECT_EQ(idx4[1], 0);
@@ -136,29 +137,29 @@ TEST(KdTreeTest, SplitterSlidingMidpoint) {
   // to the right (the highest value) and internally the splitter needs to
   // reorder the indices such that on index 3 we get value 4.
   box.max(1) = Scalar{9.0};
-  splitter(0, 0, 4, box, &split_dim, &split_idx, &split_val);
+  splitter(0, idx4.begin(), idx4.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx4.begin(), 3);
   EXPECT_EQ(split_dim, 1);
-  EXPECT_EQ(split_idx, 3);
   EXPECT_EQ(split_val, ptsx4[2](1));
   EXPECT_EQ(idx4[3], 2);
 
   // Clean middle split. A general case where the split value falls somewhere
   // inbetween the range of numbers.
   box.max(1) = Scalar{5.0};
-  splitter(0, 0, 4, box, &split_dim, &split_idx, &split_val);
+  splitter(0, idx4.begin(), idx4.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx4.begin(), 2);
   EXPECT_EQ(split_dim, 1);
-  EXPECT_EQ(split_idx, 2);
   EXPECT_EQ(split_val, (box.max(1) + box.min(1)) / Scalar{2.0});
 
   // On dimension 0 we test what happens when all values are equal. Again
   // everything moves to the left. So we want to split on index 3.
   box.max(0) = Scalar{15.0};
-  splitter(0, 0, 4, box, &split_dim, &split_idx, &split_val);
+  splitter(0, idx4.begin(), idx4.end(), box, &split, &split_dim, &split_val);
 
+  EXPECT_EQ(split - idx4.begin(), 3);
   EXPECT_EQ(split_dim, 0);
-  EXPECT_EQ(split_idx, 3);
   EXPECT_EQ(split_val, ptsx4[3](0));
 }
 


### PR DESCRIPTION
Another step in simplifying KdTree builds that also happens to give a small speedup. Changes:
* The build algorithms are now using iterators in favor of indices.