### PR TITLE
25 opencv build disabled in the build and test workflow for windows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,9 +61,6 @@ jobs:
           cmake-install: true
 
       - name: CMake OpenCV
-        # Windows latest comes with CMake 3.25 that has problems with try_compile.
-        # https://github.com/opencv/opencv/issues/22784
-        if: runner.os != 'Windows'
         uses: Jaybro/action-cmake@v1
         with:
           cmake-source-dir: opencv

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: "3.7"
 
       # On macos-latest, OpenMP is already installed but not visible to CMake.
       # Library libomp 15.0+ has been made keg-only.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the table below to get an impression of the performance provided by the [KdT
 | [nanoflann][nano] v1.3.2            | 1.5s      | ...           | 3.2s       | ...         |
 | [SciPy KDTree][spkd] v1.6.3         | ...       | 5.0s          | ...        | 547.2s      |
 | [Scikit-learn KDTree][skkd] 0.22.2  | ...       | 12.2s         | ...        | 44.5s       |
-| [pykdtree][pykd] 1.3.4              | ...       | 1.0s          | ...        | 6.6s        |
+| [pykdtree][pykd] 1.3.6              | ...       | 1.0s          | ...        | 6.6s        |
 | [OpenCV FLANN][cvfn] 4.5.2          | 1.9s      | ...           | 4.7s       | ...         |
 | PicoTree KdTree v0.7.4              | 0.9s      | 1.0s          | 2.8s       | 3.1s        |
 
@@ -63,7 +63,7 @@ Optional:
 * [Google Benchmark](https://github.com/google/benchmark) and a compiler that is compliant with the C++17 standard are needed to run any of the benchmarks. The [nanoflann](https://github.com/jlblancoc/nanoflann) and [OpenCV](https://opencv.org/) benchmarks also require their respective libraries to be installed.
 
 Python bindings:
-* [Python](https://www.python.org/). Version 3.6 or higher.
+* [Python](https://www.python.org/). Version 3.7 or higher.
 * [pybind11](https://github.com/pybind/pybind11). Used to ease the creation of Python bindings. Available under the [BSD](https://github.com/pybind/pybind11/blob/master/LICENSE) license and copyright.
 * [OpenMP](https://www.openmp.org/). For parallelization of queries.
 * [numpy](https://numpy.org/). Points and search results are represented by ndarrays.

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='pico_tree',
       package_dir={'': 'src/pyco_tree'},
       cmake_install_dir='src/pyco_tree/pico_tree',
       cmake_args=compile_cmake_args(),
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       install_requires=['numpy'],
       )


### PR DESCRIPTION
* OpenCV build re-enabled for Windows (to allow testing the OpenCV interface of PicoTree).
* Minimum required Python version updated from 3.6 to 3.7. Version 3.6 is end of life.