### PR TITLE
Install

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: opencv/opencv
-          ref: 4.5.2
+          ref: 4.6.0
           path: opencv
 
       - name: CMake Google Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include (${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
 
 project(pico_tree
     LANGUAGES CXX
-    VERSION 0.7.4
+    VERSION 0.7.5
     DESCRIPTION "PicoTree is a C++ header only library with Python bindings for nearest neighbor searches and range searches using a KdTree."
     HOMEPAGE_URL "https://github.com/Jaybro/pico_tree")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 # CMake version 3.12 provides FindPython.
-# CMake version 3.11 generalizes in which directories find_package() searches
-# for XxxConfig.cmake or FindXxx.cmake under Lin, Win, etc.
 # CMake version 3.9 provides OpenMP per language.
 cmake_minimum_required(VERSION 3.12)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the table below to get an impression of the performance provided by the [KdT
 | [Scikit-learn KDTree][skkd] 0.22.2  | ...       | 12.2s         | ...        | 44.5s       |
 | [pykdtree][pykd] 1.3.6              | ...       | 1.0s          | ...        | 6.6s        |
 | [OpenCV FLANN][cvfn] 4.6.0          | 1.9s      | ...           | 4.7s       | ...         |
-| PicoTree KdTree v0.7.4              | 0.9s      | 1.0s          | 2.8s       | 3.1s        |
+| PicoTree KdTree v0.7.5              | 0.9s      | 1.0s          | 2.8s       | 3.1s        |
 
 It compares the performance of the build and query algorithms using two [LiDAR](./docs/benchmark.md) based point clouds of sizes 7733372 and 7200863. The first point cloud is used to compare build times and both are used to compare query times. All benchmarks were generated with the following parameters: `max_leaf_size=10`, `knn=1` and `OMP_NUM_THREADS=1`. A more detailed [C++ comparison](./docs/benchmark.md) of PicoTree is available with respect to [nanoflann][nano].
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the table below to get an impression of the performance provided by the [KdT
 | [SciPy KDTree][spkd] v1.6.3         | ...       | 5.0s          | ...        | 547.2s      |
 | [Scikit-learn KDTree][skkd] 0.22.2  | ...       | 12.2s         | ...        | 44.5s       |
 | [pykdtree][pykd] 1.3.6              | ...       | 1.0s          | ...        | 6.6s        |
-| [OpenCV FLANN][cvfn] 4.5.2          | 1.9s      | ...           | 4.7s       | ...         |
+| [OpenCV FLANN][cvfn] 4.6.0          | 1.9s      | ...           | 4.7s       | ...         |
 | PicoTree KdTree v0.7.4              | 0.9s      | 1.0s          | 2.8s       | 3.1s        |
 
 It compares the performance of the build and query algorithms using two [LiDAR](./docs/benchmark.md) based point clouds of sizes 7733372 and 7200863. The first point cloud is used to compare build times and both are used to compare query times. All benchmarks were generated with the following parameters: `max_leaf_size=10`, `knn=1` and `OMP_NUM_THREADS=1`. A more detailed [C++ comparison](./docs/benchmark.md) of PicoTree is available with respect to [nanoflann][nano].

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,11 @@
 #!/usr/bin/env python3
 
-import sys
 from skbuild import setup
-
-
-def compile_cxx_flags():
-    cxx_flags = []
-
-    if sys.platform == 'win32':
-        # Old versions of CPython have a bug where "hypot" is defined as
-        # "_hypot". This definition conflicts with the one from math.h and as a
-        # result causes the following compile error in cmath using MinGW:
-        #   cmath:1121:11: error: '::hypot' has not been declared
-        #       using ::hypot;
-        # Issue and backport reference: https://github.com/python/cpython/pull/11283
-        # Issue solved: https://github.com/python/cpython/blob/v3.7.3/PC/pyconfig.h
-        python_version = sys.version_info[:3]
-        if python_version < (3, 7, 3):
-            cxx_flags.append('-D_hypot=hypot')
-
-    return cxx_flags
-
-
-def compile_cmake_args():
-    cmake_args = []
-
-    cxx_flags = compile_cxx_flags()
-    if cxx_flags:
-        cmake_args.append('-DCMAKE_CXX_FLAGS="' + ' '.join(cxx_flags) + '"')
-
-    return cmake_args
 
 
 setup(name='pico_tree',
       # The same as the CMake project version.
-      version='0.7.4',
+      version='0.7.5',
       description='PicoTree Python Bindings',
       author='Jonathan Broere',
       url='https://github.com/Jaybro/pico_tree',
@@ -42,7 +13,6 @@ setup(name='pico_tree',
       packages=['pico_tree'],
       package_dir={'': 'src/pyco_tree'},
       cmake_install_dir='src/pyco_tree/pico_tree',
-      cmake_args=compile_cmake_args(),
-      python_requires='>=3.7',
+      python_requires='>=3.7.3',
       install_requires=['numpy'],
       )

--- a/src/pico_tree/CMakeLists.txt
+++ b/src/pico_tree/CMakeLists.txt
@@ -44,12 +44,14 @@ if(NOT SKBUILD)
     # See target_include_directories
     install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_PACKAGE_TARGETS_NAME})
 
+    # Allows the target to be exported from the build tree.
     export(EXPORT ${PROJECT_PACKAGE_TARGETS_NAME}
         FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_PACKAGE_TARGETS_NAME}.cmake"
         NAMESPACE ${PROJECT_PACKAGE_NAME}::)
 
+    # The config mode search procedure uses this path for both Unix and Windows.
     set(PACKAGE_INSTALL_DESTINATION
-        ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_PACKAGE_NAME}/cmake)
+        ${PROJECT_PACKAGE_NAME}/share/cmake/${PROJECT_PACKAGE_NAME})
 
     include(CMakePackageConfigHelpers)
     write_basic_package_version_file(


### PR DESCRIPTION
* PicoTree version increased.
* OpenCV's cmake configuration did not support the latest Visual Studio, causing `find_package(OpenCV)` to fail. Updating to a newer version solved the problem.