### PR TITLE
Search visitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
 
 project(pico_tree
     LANGUAGES CXX
-    VERSION 0.8.0
+    VERSION 0.8.1
     DESCRIPTION "PicoTree is a C++ header only library for fast nearest neighbor searches and range searches using a KdTree."
     HOMEPAGE_URL "https://github.com/Jaybro/pico_tree")
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ PicoTree can interface with different types of points and point sets through tra
 * Creating a [custom search visitor](./examples/kd_tree/kd_tree_custom_search_visitor.cpp).
 * [Saving and loading](./examples/kd_tree/kd_tree_save_and_load.cpp) a KdTree to and from a file.
 * Support for [Eigen](./examples/eigen/eigen.cpp) and [OpenCV](./examples/opencv/opencv.cpp) data types.
+* Running the KdTree on the [MNIST](./examples/mnist/mnist.cpp) [database](http://yann.lecun.com/exdb/mnist/).
 * How to use the [KdTree with Python](./examples/python/kd_tree.py).
 
 # Requirements

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PicoTree is a C++ header only library with [Python bindings](https://github.com/
 | [Scikit-learn KDTree][skkd] 1.2.2   | ...       | 6.2s          | ...        | 42.2s       |
 | [pykdtree][pykd] 1.3.7              | ...       | 1.0s          | ...        | 6.6s        |
 | [OpenCV FLANN][cvfn] 4.6.0          | 1.9s      | ...           | 4.7s       | ...         |
-| PicoTree KdTree v0.8.0              | 0.9s      | 1.0s          | 2.8s       | 3.1s        |
+| PicoTree KdTree v0.8.1              | 0.9s      | 1.0s          | 2.8s       | 3.1s        |
 
 Two [LiDAR](./docs/benchmark.md) based point clouds of sizes 7733372 and 7200863 were used to generate these numbers. The first point cloud was the input to the build algorithm and the second to the query algorithm. All benchmarks were run on a single thread with the following parameters: `max_leaf_size=10` and `knn=1`. A more detailed [C++ comparison](./docs/benchmark.md) of PicoTree is available with respect to [nanoflann][nano].
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,10 @@ else()
     message(STATUS "benchmark not found. PicoTree benchmarks skipped.")
 endif()
 
+if(Eigen3_FOUND)
+    add_subdirectory(mnist)
+endif()
+
 # The Python examples only get copied when the bindings module will be build.
 if(TARGET _pyco_tree)
     add_subdirectory(python)

--- a/examples/benchmark/bm_opencv_flann.cpp
+++ b/examples/benchmark/bm_opencv_flann.cpp
@@ -116,9 +116,10 @@ BENCHMARK_DEFINE_F(BmOpenCvFlann, KnnCt)(benchmark::State& state) {
   // There is also the option to query them all at once, but this doesn't really
   // change performance and this version looks more like the other benchmarks.
   for (auto _ : state) {
-    std::vector<Index> indices(knn_count);
+    // The only supported index type is int.
+    std::vector<int> indices(knn_count);
     std::vector<Scalar> distances(knn_count);
-    fl::Matrix<Index> mat_indices(indices.data(), 1, knn_count);
+    fl::Matrix<int> mat_indices(indices.data(), 1, knn_count);
     fl::Matrix<Scalar> mat_distances(distances.data(), 1, knn_count);
 
     for (auto& p : points_test_) {

--- a/examples/mnist/CMakeLists.txt
+++ b/examples/mnist/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(mnist mnist.cpp)
+set_default_target_properties(mnist)
+target_link_libraries(mnist PUBLIC pico_toolshed pico_understory Eigen3::Eigen)

--- a/examples/mnist/mnist.cpp
+++ b/examples/mnist/mnist.cpp
@@ -1,0 +1,122 @@
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <pico_toolshed/format/format_bin.hpp>
+#include <pico_toolshed/format/format_mnist.hpp>
+#include <pico_toolshed/scoped_timer.hpp>
+#include <pico_tree/array_traits.hpp>
+#include <pico_tree/kd_tree.hpp>
+#include <pico_tree/vector_traits.hpp>
+#include <pico_understory/rkd_tree.hpp>
+
+template <typename U, typename T, std::size_t N>
+std::array<U, N> Cast(std::array<T, N> const& i) {
+  std::array<U, N> c;
+  std::transform(i.begin(), i.end(), c.begin(), [](T a) -> U {
+    return static_cast<U>(a);
+  });
+  return c;
+}
+
+template <std::size_t N>
+std::vector<std::array<float, N>> Cast(
+    std::vector<std::array<std::byte, N>> const& i) {
+  std::vector<std::array<float, N>> c;
+  std::transform(
+      i.begin(),
+      i.end(),
+      std::back_inserter(c),
+      [](std::array<std::byte, N> const& a) -> std::array<float, N> {
+        return Cast<float>(a);
+      });
+  return c;
+}
+
+int main(int argc, char** argv) {
+  using ImageByte = std::array<std::byte, 28 * 28>;
+  using ImageFloat = std::array<float, 28 * 28>;
+
+  std::string fn_images_train = "train-images.idx3-ubyte";
+  std::string fn_images_test = "t10k-images.idx3-ubyte";
+  std::string fn_mnist_nns_gt = "mnist_nns_gt.bin";
+
+  if (!std::filesystem::exists(fn_images_train)) {
+    std::cout << fn_images_train << " doesn't exist." << std::endl;
+    return 0;
+  }
+
+  if (!std::filesystem::exists(fn_images_test)) {
+    std::cout << fn_images_test << " doesn't exist." << std::endl;
+    return 0;
+  }
+
+  std::vector<ImageFloat> images_train;
+  {
+    std::vector<ImageByte> images_train_u8;
+    pico_tree::ReadMnistImages(fn_images_train, images_train_u8);
+    images_train = Cast(images_train_u8);
+  }
+
+  std::vector<ImageFloat> images_test;
+  {
+    std::vector<ImageByte> images_test_u8;
+    pico_tree::ReadMnistImages(fn_images_test, images_test_u8);
+    images_test = Cast(images_test_u8);
+  }
+
+  std::size_t max_leaf_size_ex = 16;
+  std::size_t max_leaf_size_rp = 128;
+  // With 16 trees we can get a precision of around 85-90%.
+  // With 32 trees we can get a precision of around 95-97%.
+  std::size_t forest_size = 2;
+  std::size_t count = images_test.size();
+  std::vector<pico_tree::Neighbor<int, float>> nns(count);
+
+  if (!std::filesystem::exists(fn_images_train)) {
+    auto kd_tree = [&images_train, &max_leaf_size_ex]() {
+      ScopedTimer t0("kd_tree build");
+      return pico_tree::KdTree<std::reference_wrapper<std::vector<ImageFloat>>>(
+          images_train, max_leaf_size_ex);
+    }();
+
+    {
+      ScopedTimer t1("kd_tree query");
+      for (std::size_t i = 0; i < nns.size(); ++i) {
+        kd_tree.SearchNn(images_test[i], nns[i]);
+      }
+    }
+
+    std::cout << "Writing " << fn_mnist_nns_gt << "." << std::endl;
+    pico_tree::WriteBin(fn_mnist_nns_gt, nns);
+  } else {
+    std::cout << "Reading " << fn_mnist_nns_gt << "." << std::endl;
+    pico_tree::ReadBin(fn_mnist_nns_gt, nns);
+  }
+
+  std::size_t equal = 0;
+
+  {
+    auto rkd_tree = [&images_train, &max_leaf_size_rp, &forest_size]() {
+      ScopedTimer t0("rkd_tree build");
+      return pico_tree::RKdTree<
+          std::reference_wrapper<std::vector<ImageFloat>>>(
+          images_train, max_leaf_size_rp, forest_size);
+    }();
+
+    ScopedTimer t1("rkd_tree query");
+    pico_tree::Neighbor<int, float> nn;
+    for (std::size_t i = 0; i < nns.size(); ++i) {
+      rkd_tree.SearchNn(images_test[i], nn);
+
+      if (nns[i].index == nn.index) {
+        ++equal;
+      }
+    }
+  }
+
+  std::cout << "Precision: "
+            << (static_cast<float>(equal) / static_cast<float>(count))
+            << std::endl;
+
+  return 0;
+}

--- a/examples/pico_understory/CMakeLists.txt
+++ b/examples/pico_understory/CMakeLists.txt
@@ -3,6 +3,12 @@ target_include_directories(pico_understory INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(pico_understory INTERFACE PicoTree::PicoTree)
 target_sources(pico_understory
     INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/pico_understory/cover_tree.hpp
-        ${CMAKE_CURRENT_LIST_DIR}/pico_understory/metric.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_base.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_builder.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_data.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_node.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_search.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/static_buffer.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/cover_tree.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/metric.hpp
 )

--- a/examples/pico_understory/CMakeLists.txt
+++ b/examples/pico_understory/CMakeLists.txt
@@ -8,7 +8,11 @@ target_sources(pico_understory
     ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_data.hpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_node.hpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/cover_tree_search.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/rkd_tree_builder.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/rkd_tree_rr_data.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/rkd_tree_search.hpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_understory/internal/static_buffer.hpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_understory/cover_tree.hpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_understory/metric.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_understory/rkd_tree.hpp
 )

--- a/examples/pico_understory/pico_understory/internal/eigen3.hpp
+++ b/examples/pico_understory/pico_understory/internal/eigen3.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include "pico_tree/core.hpp"
+
+namespace pico_tree::internal {
+
+constexpr int PicoDimToEigenDim(pico_tree::Size dim) {
+  return dim == pico_tree::kDynamicSize ? Eigen::Dynamic
+                                        : static_cast<int>(dim);
+}
+
+template <typename Scalar_, int Dim_>
+using VectorDX = Eigen::Matrix<Scalar_, Dim_, 1>;
+
+}  // namespace pico_tree::internal

--- a/examples/pico_understory/pico_understory/internal/rkd_tree_builder.hpp
+++ b/examples/pico_understory/pico_understory/internal/rkd_tree_builder.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <random>
+
+#include "pico_tree/internal/kd_tree_builder.hpp"
+#include "rkd_tree_rr_data.hpp"
+
+namespace pico_tree::internal {
+
+template <typename Node_, Size Dim_, SplittingRule SplittingRule_>
+class BuildRKdTree {
+ public:
+  using RKdTreeDataType = RKdTreeRrData<Node_, Dim_>;
+
+  template <typename SpaceWrapper_>
+  std::vector<RKdTreeDataType> operator()(
+      SpaceWrapper_ space, Size max_leaf_size, Size forest_size) {
+    assert(space.size() > 0);
+    assert(max_leaf_size > 0);
+    assert(forest_size > 0);
+
+    using SpaceWrapperType = typename RKdTreeDataType::SpaceWrapperType;
+    using BuildKdTreeType = BuildKdTree<Node_, Dim_, SplittingRule_>;
+
+    std::vector<RKdTreeDataType> trees(forest_size);
+    for (std::size_t i = 0; i < forest_size; ++i) {
+      auto r = RKdTreeDataType::RandomRotation(space);
+      auto s = RKdTreeDataType::RotateSpace(r, space);
+      auto t = BuildKdTreeType()(SpaceWrapperType(s), max_leaf_size);
+      trees[i] = {std::move(r), std::move(s), std::move(t)};
+    }
+    return trees;
+  }
+};
+
+}  // namespace pico_tree::internal

--- a/examples/pico_understory/pico_understory/internal/rkd_tree_rr_data.hpp
+++ b/examples/pico_understory/pico_understory/internal/rkd_tree_rr_data.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "eigen3.hpp"
+#include "pico_tree/eigen3_traits.hpp"
+#include "pico_tree/internal/kd_tree_data.hpp"
+#include "pico_tree/internal/space_wrapper.hpp"
+
+namespace pico_tree::internal {
+
+//! \brief Sample from the uniform distribution on the Stiefel manifold (the set
+//! of all orthonormal k-frames in R^n).
+//! \details Sample = Z(Z^TZ)^(-1/2). Z has elements drawn from N(0,1).
+//! The matrix may be improper.
+template <typename Scalar_>
+inline Eigen::Matrix<Scalar_, Eigen::Dynamic, Eigen::Dynamic>
+RandomOrthogonalMatrix(pico_tree::Size dim) {
+  // Working with floats makes all but JacobiSVD fail. Results for all are not
+  // that accurate as well ((m * m.transpose()).diagonal().sum()).
+  // * JacobiSVD<,Eigen::NoQRPreconditioner> never failed but slow.
+  // * BDCSVD / bdcSvd may lose a rank or 2.
+  // * SelfAdjointEigenSolver may lose 1 rank.
+  // Solution: don't use float.
+  // Reproduce: Matrix S = d.matrixU() *
+  //            d.singularValues().cwiseInverse().cwiseSqrt().asDiagonal() *
+  //            d.matrixU().transpose();
+  //            // Eigen::DecompositionOptions::ComputeThinU
+  using T = double;
+  using Matrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+
+  std::random_device rd;
+  std::mt19937 e(rd());
+  std::normal_distribution<T> gaussian(T(0), T(1));
+
+  Matrix X = Matrix::Zero(dim, dim).unaryExpr(
+      [&gaussian, &e](T dummy) { return gaussian(e); });
+
+  Matrix XtX = X.transpose() * X;
+  Eigen::SelfAdjointEigenSolver<Matrix> d(XtX);
+  Matrix S = d.operatorInverseSqrt();
+  // Returns the frames per row. Doesn't matter.
+  if constexpr (std::is_same_v<Scalar_, T>) {
+    return X * S;
+  } else {
+    return (X * S).cast<Scalar_>();
+  }
+}
+
+template <typename Node_, Size Dim_>
+class RKdTreeRrData {
+  template <typename T, int Cols_ = PicoDimToEigenDim(Dim_)>
+  using VectorType = VectorDX<T, Cols_>;
+
+ public:
+  using ScalarType = typename Node_::ScalarType;
+  static Size constexpr Dim = Dim_;
+  using NodeType = Node_;
+  using RotationType =
+      Eigen::Matrix<ScalarType, Eigen::Dynamic, Eigen::Dynamic>;
+  using SpaceType =
+      Eigen::Matrix<ScalarType, PicoDimToEigenDim(Dim_), Eigen::Dynamic>;
+  using SpaceWrapperType = SpaceWrapper<SpaceType>;
+
+  template <typename SpaceWrapper_>
+  static inline auto RandomRotation(SpaceWrapper_ space) {
+    return RandomOrthogonalMatrix<ScalarType>(space.sdim());
+  }
+
+  template <typename SpaceWrapper_>
+  static inline SpaceType RotateSpace(
+      RotationType const& rotation, SpaceWrapper_ space) {
+    SpaceType s(static_cast<int>(space.sdim()), static_cast<int>(space.size()));
+    for (std::size_t i = 0; i < space.size(); ++i) {
+      Eigen::Map<Eigen::Matrix<ScalarType, PicoDimToEigenDim(Dim_), 1> const> p(
+          space[i], static_cast<int>(space.sdim()));
+      s.col(i) = rotation * p;
+    }
+    return s;
+  }
+
+  template <typename PointWrapper_>
+  VectorType<ScalarType> RotatePoint(PointWrapper_ w) const {
+    Eigen::Map<VectorType<ScalarType> const> p(w.begin(), space.rows());
+    return rotation * p;
+  }
+
+  RotationType rotation;
+  SpaceType space;
+  KdTreeData<Node_, Dim_> tree;
+};
+
+}  // namespace pico_tree::internal

--- a/examples/pico_understory/pico_understory/internal/rkd_tree_search.hpp
+++ b/examples/pico_understory/pico_understory/internal/rkd_tree_search.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <type_traits>
+
+#include "pico_tree/internal/kd_tree_node.hpp"
+#include "pico_tree/internal/point.hpp"
+#include "pico_tree/metric.hpp"
+
+namespace pico_tree::internal {
+
+//! \brief This class provides a search nearest function for Euclidean spaces.
+template <
+    typename SpaceWrapper_,
+    typename Metric_,
+    typename PointWrapper_,
+    typename Visitor_,
+    typename Index_>
+class SearchNearestEuclideanDefeatist {
+ public:
+  using IndexType = Index_;
+  using ScalarType = typename SpaceWrapper_::ScalarType;
+  //! \brief Node type supported by this SearchNearestEuclideanDefeatist.
+  using NodeType = KdTreeNodeEuclidean<IndexType, ScalarType>;
+
+  inline SearchNearestEuclideanDefeatist(
+      SpaceWrapper_ space,
+      Metric_ metric,
+      std::vector<IndexType> const& indices,
+      PointWrapper_ query,
+      Visitor_& visitor)
+      : space_(space),
+        metric_(metric),
+        indices_(indices),
+        query_(query),
+        visitor_(visitor) {}
+
+  //! \brief Search nearest neighbors starting from \p node.
+  inline void operator()(NodeType const* const node) { SearchNearest(node); }
+
+ private:
+  inline void SearchNearest(NodeType const* const node) {
+    if (node->IsLeaf()) {
+      for (IndexType i = node->data.leaf.begin_idx; i < node->data.leaf.end_idx;
+           ++i) {
+        ScalarType const d =
+            metric_(query_.begin(), query_.end(), space_[indices_[i]]);
+        if (visitor_.max() > d) {
+          visitor_(indices_[i], d);
+        }
+      }
+    } else {
+      ScalarType const v = query_[node->data.branch.split_dim];
+      NodeType const* node_1st;
+
+      // On equals we would possibly need to go left as well if we wanted exact
+      // nearest neighbors. However, this search algorithm is solely used for
+      // approximate nearest neighbor searches. So we'll consider it bad luck.
+      // If left_max - v > 0, this means that the query is inside the left node,
+      // if right_min - v < 0 it's inside the right one. For the area in between
+      // we just pick the closest one by summing them.
+      if ((node->data.branch.left_max + node->data.branch.right_min - v - v) >
+          0) {
+        node_1st = node->left;
+      } else {
+        node_1st = node->right;
+      }
+
+      SearchNearest(node_1st);
+    }
+  }
+
+  SpaceWrapper_ space_;
+  Metric_ metric_;
+  std::vector<IndexType> const& indices_;
+  PointWrapper_ query_;
+  Visitor_& visitor_;
+};
+
+}  // namespace pico_tree::internal

--- a/examples/pico_understory/pico_understory/rkd_tree.hpp
+++ b/examples/pico_understory/pico_understory/rkd_tree.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <pico_tree/internal/point_wrapper.hpp>
+#include <pico_tree/internal/space_wrapper.hpp>
+#include <pico_tree/metric.hpp>
+
+#include "pico_understory/internal/rkd_tree_builder.hpp"
+#include "pico_understory/internal/rkd_tree_search.hpp"
+
+namespace pico_tree {
+
+template <
+    typename Space_,
+    typename Metric_ = L2Squared,
+    SplittingRule SplittingRule_ = SplittingRule::kSlidingMidpoint,
+    typename Index_ = int>
+class RKdTree {
+  using SpaceWrapperType = internal::SpaceWrapper<Space_>;
+  //! \brief Node type based on Metric_::SpaceTag.
+  using NodeType =
+      typename internal::KdTreeSpaceTagTraits<typename Metric_::SpaceTag>::
+          template NodeType<Index_, typename SpaceWrapperType::ScalarType>;
+  using BuildRKdTreeType =
+      internal::BuildRKdTree<NodeType, SpaceWrapperType::Dim, SplittingRule_>;
+  using RKdTreeDataType = typename BuildRKdTreeType::RKdTreeDataType;
+
+ public:
+  //! \brief Size type.
+  using SizeType = Size;
+  //! \brief Index type.
+  using IndexType = Index_;
+  //! \brief Scalar type.
+  using ScalarType = typename SpaceWrapperType::ScalarType;
+  //! \brief KdTree dimension. It equals pico_tree::kDynamicSize in case Dim is
+  //! only known at run-time.
+  static SizeType constexpr Dim = SpaceWrapperType::Dim;
+  //! \brief Point set or adaptor type.
+  using SpaceType = Space_;
+  //! \brief The metric used for various searches.
+  using MetricType = Metric_;
+  //! \brief Neighbor type of various search resuls.
+  using NeighborType = Neighbor<IndexType, ScalarType>;
+
+  RKdTree(SpaceType space, SizeType max_leaf_size, SizeType forest_size)
+      : space_(std::move(space)),
+        metric_(),
+        data_(BuildRKdTreeType()(
+            SpaceWrapperType(space_), max_leaf_size, forest_size)) {}
+
+  //! \brief The RKdTree cannot be copied.
+  //! \details The RKdTree uses pointers to nodes and copying pointers is not
+  //! the same as creating a deep copy.
+  RKdTree(RKdTree const&) = delete;
+
+  //! \brief Move constructor of the RKdTree.
+  RKdTree(RKdTree&&) = default;
+
+  //! \brief RKdTree copy assignment.
+  RKdTree& operator=(RKdTree const& other) = delete;
+
+  //! \brief RKdTree move assignment.
+  RKdTree& operator=(RKdTree&& other) = default;
+
+  //! \brief Returns the nearest neighbor (or neighbors) of point \p x depending
+  //! on their selection by visitor \p visitor .
+  //! \see internal::SearchNn
+  //! \see internal::SearchKnn
+  //! \see internal::SearchRadius
+  //! \see internal::SearchAknn
+  template <typename P, typename V>
+  inline void SearchNearest(P const& x, V& visitor) const {
+    internal::PointWrapper<P> p(x);
+    SearchNearest(p, visitor, typename Metric_::SpaceTag());
+  }
+
+  //! \brief Searches for the nearest neighbor of point \p x.
+  //! \details Interpretation of the output distance depends on the Metric. The
+  //! default L2Squared results in a squared distance.
+  template <typename P>
+  inline void SearchNn(P const& x, NeighborType& nn) const {
+    internal::SearchNn<NeighborType> v(nn);
+    SearchNearest(x, v);
+  }
+
+ private:
+  //! \brief Returns the nearest neighbor (or neighbors) of point \p x depending
+  //! on their selection by visitor \p visitor for node \p node.
+  template <typename PointWrapper_, typename Visitor_>
+  inline void SearchNearest(
+      PointWrapper_ point, Visitor_& visitor, EuclideanSpaceTag) const {
+    // Range based for loop (rightfully) results in a warning that shouldn't be
+    // needed if the user creates the forest with at least a single tree.
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      auto p = data_[i].RotatePoint(point);
+      using PointWrapperType = internal::PointWrapper<decltype(p)>;
+      PointWrapperType w(p);
+      internal::SearchNearestEuclideanDefeatist<
+          typename RKdTreeDataType::SpaceWrapperType,
+          Metric_,
+          PointWrapperType,
+          Visitor_,
+          IndexType>(
+          typename RKdTreeDataType::SpaceWrapperType(data_[i].space),
+          metric_,
+          data_[i].tree.indices,
+          w,
+          visitor)(data_[i].tree.root_node);
+    }
+  }
+
+  //! \brief Point set used for querying point data.
+  SpaceType space_;
+  //! \brief Metric used for comparing distances.
+  MetricType metric_;
+  //! \brief Data structure of the KdTree.
+  std::vector<RKdTreeDataType> data_;
+};
+
+}  // namespace pico_tree

--- a/examples/pico_understory/pico_understory/rkd_tree.hpp
+++ b/examples/pico_understory/pico_understory/rkd_tree.hpp
@@ -63,10 +63,6 @@ class RKdTree {
 
   //! \brief Returns the nearest neighbor (or neighbors) of point \p x depending
   //! on their selection by visitor \p visitor .
-  //! \see internal::SearchNn
-  //! \see internal::SearchKnn
-  //! \see internal::SearchRadius
-  //! \see internal::SearchAknn
   template <typename P, typename V>
   inline void SearchNearest(P const& x, V& visitor) const {
     internal::PointWrapper<P> p(x);

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from skbuild import setup
 
 setup(name='pico_tree',
       # The same as the CMake project version.
-      version='0.8.0',
+      version='0.8.1',
       description='PicoTree Python Bindings',
       author='Jonathan Broere',
       url='https://github.com/Jaybro/pico_tree',

--- a/src/pico_tree/pico_tree/eigen3_traits.hpp
+++ b/src/pico_tree/pico_tree/eigen3_traits.hpp
@@ -184,6 +184,27 @@ struct SpaceTraits<Eigen::Map<
           MapOptions_,
           StrideType_>> {};
 
+//! \brief EigenTraits provides an interface for Eigen::Map<Eigen::Matrix<>
+//! const>.
+template <
+    typename Scalar_,
+    int Rows_,
+    int Cols_,
+    int Options_,
+    int MaxRows_,
+    int MaxCols_,
+    int MapOptions_,
+    typename StrideType_>
+struct SpaceTraits<Eigen::Map<
+    Eigen::Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_> const,
+    MapOptions_,
+    StrideType_>>
+    : public internal::EigenTraitsImpl<Eigen::Map<
+          Eigen::
+              Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_> const,
+          MapOptions_,
+          StrideType_>> {};
+
 //! \brief PointTraits provides an interface for Eigen::Matrix<>.
 template <
     typename Scalar_,
@@ -214,6 +235,27 @@ struct PointTraits<Eigen::Map<
     StrideType_>>
     : public internal::EigenPointTraits<Eigen::Map<
           Eigen::Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_>,
+          MapOptions_,
+          StrideType_>> {};
+
+//! \brief PointTraits provides an interface for Eigen::Map<Eigen::Matrix<>
+//! const>.
+template <
+    typename Scalar_,
+    int Rows_,
+    int Cols_,
+    int Options_,
+    int MaxRows_,
+    int MaxCols_,
+    int MapOptions_,
+    typename StrideType_>
+struct PointTraits<Eigen::Map<
+    Eigen::Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_> const,
+    MapOptions_,
+    StrideType_>>
+    : public internal::EigenPointTraits<Eigen::Map<
+          Eigen::
+              Matrix<Scalar_, Rows_, Cols_, Options_, MaxRows_, MaxCols_> const,
           MapOptions_,
           StrideType_>> {};
 

--- a/src/pico_tree/pico_tree/eigen3_traits.hpp
+++ b/src/pico_tree/pico_tree/eigen3_traits.hpp
@@ -31,7 +31,7 @@ template <typename T>
 inline constexpr bool is_matrix_base_v = is_matrix_base<T>::value;
 
 template <typename Derived>
-constexpr Eigen::Index EigenVectorDim() {
+constexpr int EigenVectorDim() {
   static_assert(
       (!Derived::IsRowMajor && Derived::ColsAtCompileTime == 1) ||
           (Derived::IsRowMajor && Derived::RowsAtCompileTime == 1),
@@ -40,7 +40,7 @@ constexpr Eigen::Index EigenVectorDim() {
                              : Derived::RowsAtCompileTime;
 }
 
-constexpr Size EigenDimToPicoDim(Eigen::Index dim) {
+constexpr Size EigenDimToPicoDim(int dim) {
   return dim == Eigen::Dynamic ? kDynamicSize : static_cast<Size>(dim);
 }
 

--- a/src/pico_tree/pico_tree/internal/kd_tree_node.hpp
+++ b/src/pico_tree/pico_tree/internal/kd_tree_node.hpp
@@ -71,6 +71,14 @@ struct KdTreeNodeEuclidean
   using IndexType = Index_;
   using ScalarType = Scalar_;
 
+  template <typename Box_>
+  inline void SetBranch(
+      Box_ const& left_box, Box_ const& right_box, Size const split_dim) {
+    data.branch.split_dim = static_cast<int>(split_dim);
+    data.branch.left_max = left_box.max(split_dim);
+    data.branch.right_min = right_box.min(split_dim);
+  }
+
   //! \brief Node data as a union of a leaf and branch.
   KdTreeNodeData<KdTreeLeaf<Index_>, KdTreeBranchSplit<Scalar_>> data;
 };
@@ -81,6 +89,16 @@ struct KdTreeNodeTopological
     : public KdTreeNodeBase<KdTreeNodeTopological<Index_, Scalar_>> {
   using IndexType = Index_;
   using ScalarType = Scalar_;
+
+  template <typename Box_>
+  inline void SetBranch(
+      Box_ const& left_box, Box_ const& right_box, Size const split_dim) {
+    data.branch.split_dim = static_cast<int>(split_dim);
+    data.branch.left_min = left_box.min(split_dim);
+    data.branch.left_max = left_box.max(split_dim);
+    data.branch.right_min = right_box.min(split_dim);
+    data.branch.right_max = right_box.max(split_dim);
+  }
 
   //! \brief Node data as a union of a leaf and branch.
   KdTreeNodeData<KdTreeLeaf<Index_>, KdTreeBranchRange<Scalar_>> data;

--- a/src/pico_tree/pico_tree/internal/kd_tree_search.hpp
+++ b/src/pico_tree/pico_tree/internal/kd_tree_search.hpp
@@ -49,11 +49,9 @@ class SearchNearestEuclidean {
     if (node->IsLeaf()) {
       for (IndexType i = node->data.leaf.begin_idx; i < node->data.leaf.end_idx;
            ++i) {
-        ScalarType const d =
-            metric_(query_.begin(), query_.end(), space_[indices_[i]]);
-        if (visitor_.max() > d) {
-          visitor_(indices_[i], d);
-        }
+        visitor_(
+            indices_[i],
+            metric_(query_.begin(), query_.end(), space_[indices_[i]]));
       }
     } else {
       // Go left or right and then check if we should still go down the other
@@ -156,11 +154,9 @@ class SearchNearestTopological {
     if (node->IsLeaf()) {
       for (IndexType i = node->data.leaf.begin_idx; i < node->data.leaf.end_idx;
            ++i) {
-        ScalarType const d =
-            metric_(query_.begin(), query_.end(), space_[indices_[i]]);
-        if (visitor_.max() > d) {
-          visitor_(indices_[i], d);
-        }
+        visitor_(
+            indices_[i],
+            metric_(query_.begin(), query_.end(), space_[indices_[i]]));
       }
     } else {
       // Go left or right and then check if we should still go down the other

--- a/src/pyco_tree/pico_tree/_pyco_tree/def_kd_tree.cpp
+++ b/src/pyco_tree/pico_tree/_pyco_tree/def_kd_tree.cpp
@@ -199,6 +199,38 @@ and store the result in the specified output.
 Search for all neighbors within a radius of each of the input points.
 )ptdoc")
       .def(
+          "search_radius",
+          static_cast<void (KdTree::*)(
+              py::array_t<Scalar, 0> const,
+              Scalar const,
+              Scalar const,
+              Neighborhoods&,
+              bool const) const>(&KdTree::SearchRadius),
+          py::arg("pts").noconvert().none(false),
+          py::arg("radius").none(false),
+          py::arg("e").none(false),
+          py::arg("nns").noconvert().none(false),
+          py::arg("sort").none(false) = false,
+          R"ptdoc(
+Search for the approximate neighbors within a radius of each of the
+input points and store the result in the specified output.
+)ptdoc")
+      .def(
+          "search_radius",
+          static_cast<Neighborhoods (KdTree::*)(
+              py::array_t<Scalar, 0> const,
+              Scalar const,
+              Scalar const,
+              bool const) const>(&KdTree::SearchRadius),
+          py::arg("pts").noconvert().none(false),
+          py::arg("radius").none(false),
+          py::arg("e").none(false),
+          py::arg("sort").none(false) = false,
+          R"ptdoc(
+Search for the approximate neighbors within a radius of each of the
+input points.
+)ptdoc")
+      .def(
           "search_box",
           static_cast<void (KdTree::*)(
               py::array_t<Scalar, 0> const, Neighborhoods&) const>(


### PR DESCRIPTION
The biggest change introduced by this PR moves the responsibility of filtering points from the KdTree to the search visitor. Previously, the KdTree would use a visitor's `max()` method to filter both the nodes of the tree as well as the points residing in the non-filtered nodes. Moving this responsibility makes it possible for the visitor to inspect all the points of the non-filtered nodes instead of a sub-set. This has the following advantages:
* Allows the introduction of an approximate radius search.
* Allows us to know the exact amount of points encountered during a query (see `kd_tree_custom_search_visitor.cpp`).

Other changes:
* Added support for interfacing with an `Eigen::Map` of `const Eigen::Matrix`. There was only support for non-const matrices.
* Added the approximate version of `SearchNn` for C++.
* Added the approximate version of `SearchRadius` for C++.
* Added the approximate version of `search_radius` for Python.
* Added the `RKdTree` class to pico_understory. It uses multiple randomly rotated KdTrees for approximate nearest neighbor searching.
* Added the MNIST example that compares the KdTree vs. the RKdTree.